### PR TITLE
OCF provides own macros for MIN, MAX, and DIV_ROUND_UP

### DIFF
--- a/src/cleaning/acp.c
+++ b/src/cleaning/acp.c
@@ -695,7 +695,7 @@ int cleaning_policy_acp_add_core(ocf_cache_t cache,
 		ocf_core_id_t core_id)
 {
 	uint64_t core_size = cache->core_conf_meta[core_id].length;
-	uint64_t num_chunks = DIV_ROUND_UP(core_size, ACP_CHUNK_SIZE);
+	uint64_t num_chunks = OCF_DIV_ROUND_UP(core_size, ACP_CHUNK_SIZE);
 	struct acp_context *acp = _acp_get_ctx_from_cache(cache);
 	int i;
 

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -200,7 +200,7 @@ static int _ocf_discard_step(struct ocf_request *req)
 
 	req->byte_position = SECTORS_TO_BYTES(req->discard.sector +
 			req->discard.handled);
-	req->byte_length = MIN(SECTORS_TO_BYTES(req->discard.nr_sects -
+	req->byte_length = OCF_MIN(SECTORS_TO_BYTES(req->discard.nr_sects -
 			req->discard.handled), MAX_TRIM_RQ_SIZE);
 	req->core_line_first = ocf_bytes_2_lines(cache, req->byte_position);
 	req->core_line_last =

--- a/src/metadata/metadata_hash.c
+++ b/src/metadata/metadata_hash.c
@@ -85,11 +85,11 @@ static ocf_cache_line_t ocf_metadata_hash_get_entires(
 				OCF_HASH_PRIME - 1;
 
 	case metadata_segment_sb_config:
-		return DIV_ROUND_UP(sizeof(struct ocf_superblock_config),
+		return OCF_DIV_ROUND_UP(sizeof(struct ocf_superblock_config),
 				PAGE_SIZE);
 
 	case metadata_segment_sb_runtime:
-		return DIV_ROUND_UP(sizeof(struct ocf_superblock_runtime),
+		return OCF_DIV_ROUND_UP(sizeof(struct ocf_superblock_runtime),
 				PAGE_SIZE);
 
 	case metadata_segment_reserved:
@@ -247,7 +247,7 @@ static int ocf_metadata_hash_calculate_metadata_size(
 			 * Setup SSD location and size
 			 */
 			raw->ssd_pages_offset = count_pages;
-			raw->ssd_pages = DIV_ROUND_UP(raw->entries,
+			raw->ssd_pages = OCF_DIV_ROUND_UP(raw->entries,
 					raw->entries_in_page);
 
 			/* Update offset for next container */
@@ -495,7 +495,7 @@ static int ocf_metadata_hash_init(struct ocf_cache *cache,
 		 * Setup SSD location and size
 		 */
 		raw->ssd_pages_offset = page;
-		raw->ssd_pages = DIV_ROUND_UP(raw->entries,
+		raw->ssd_pages = OCF_DIV_ROUND_UP(raw->entries,
 				raw->entries_in_page);
 
 		/* Update offset for next container */

--- a/src/metadata/metadata_io.c
+++ b/src/metadata/metadata_io.c
@@ -90,7 +90,7 @@ int metadata_io_read_i_atomic(struct ocf_cache *cache,
 	count = io_sectors_count;
 	for (i = 0; i < io_sectors_count; i += curr_count) {
 		/* Get sectors count of this IO iteration */
-		curr_count = MIN(max_sectors_count, count);
+		curr_count = OCF_MIN(max_sectors_count, count);
 
 		env_completion_init(&meta_atom_req.complete);
 		meta_atom_req.error = 0;
@@ -268,7 +268,7 @@ int metadata_io_write_i_asynch(struct ocf_cache *cache, uint32_t queue,
 {
 	uint32_t curr_count, written;
 	uint32_t max_count = metadata_io_max_page(cache);
-	uint32_t io_count = DIV_ROUND_UP(count, max_count);
+	uint32_t io_count = OCF_DIV_ROUND_UP(count, max_count);
 	uint32_t i, i_fill;
 	int error = 0, ret;
 	struct ocf_io *io;
@@ -546,7 +546,7 @@ static int metadata_io(struct metadata_io *mio)
 	env_completion_init(&mio->completion);
 
 	while (count) {
-		this_count = MIN(count, max_count);
+		this_count = OCF_MIN(count, max_count);
 
 		err = metadata_submit_io(cache, mio, this_count, written);
 		if (err)

--- a/src/metadata/metadata_raw.c
+++ b/src/metadata/metadata_raw.c
@@ -128,7 +128,7 @@ static uint32_t _raw_ram_size_on_ssd(struct ocf_cache *cache,
 {
 	const size_t alignment = 128 * KiB / PAGE_SIZE;
 
-	return DIV_ROUND_UP(raw->ssd_pages, alignment) * alignment;
+	return OCF_DIV_ROUND_UP(raw->ssd_pages, alignment) * alignment;
 }
 
 /*

--- a/src/metadata/metadata_raw_dynamic.c
+++ b/src/metadata/metadata_raw_dynamic.c
@@ -190,7 +190,7 @@ uint32_t raw_dynamic_size_on_ssd(struct ocf_cache *cache,
 {
 	const size_t alignment = 128 * KiB / PAGE_SIZE;
 
-	return DIV_ROUND_UP(raw->ssd_pages, alignment) * alignment;
+	return OCF_DIV_ROUND_UP(raw->ssd_pages, alignment) * alignment;
 }
 
 /*

--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -210,8 +210,8 @@ static unsigned long _ocf_mngt_find_first_free_core(const unsigned long *bitmap)
 	for (i = 0; i * sizeof(unsigned long) * 8 < OCF_CORE_MAX; i++) {
 		unsigned long long ignore_mask = (i == 0) ? 1UL : 0UL;
 		if (~(bitmap[i] | ignore_mask)) {
-			ret = MIN(OCF_CORE_MAX, i * sizeof(unsigned long) * 8 +
-				  _ffz(bitmap[i] | ignore_mask));
+			ret = OCF_MIN(OCF_CORE_MAX, i * sizeof(unsigned long) *
+					8 + _ffz(bitmap[i] | ignore_mask));
 			break;
 		}
 	}
@@ -243,7 +243,7 @@ static int __ocf_mngt_lookup_core_uuid(ocf_cache_t cache,
 		}
 
 		if (!env_strncmp(core->obj.uuid.data, cfg->uuid.data,
-				min(core->obj.uuid.size,
+				OCF_MIN(core->obj.uuid.size,
 				cfg->uuid.size)))
 			return i;
 	}

--- a/src/mngt/ocf_mngt_core_pool.c
+++ b/src/mngt/ocf_mngt_core_pool.c
@@ -83,7 +83,7 @@ ocf_data_obj_t ocf_mngt_core_pool_lookup(ocf_ctx_t ctx, ocf_uuid_t uuid,
 	list_for_each_entry(sobj, &ctx->core_pool.core_pool_head,
 			core_pool_item) {
 		if (sobj->type == type && !env_strncmp(sobj->uuid.data,
-				uuid->data, min(sobj->uuid.size, uuid->size))) {
+			uuid->data, OCF_MIN(sobj->uuid.size, uuid->size))) {
 			return sobj;
 		}
 	}

--- a/src/mngt/ocf_mngt_flush.c
+++ b/src/mngt/ocf_mngt_flush.c
@@ -264,10 +264,10 @@ static void _ocf_mngt_flush_portion(struct flush_container *fc)
 	/* regardless those calculations, limit flush portion to be
 	 * between OCF_MNG_FLUSH_MIN and OCF_MNG_FLUSH_MAX
 	 */
-	fc->flush_portion = MIN(fc->flush_portion, OCF_MNG_FLUSH_MAX);
-	fc->flush_portion = MAX(fc->flush_portion, OCF_MNG_FLUSH_MIN);
+	fc->flush_portion = OCF_MIN(fc->flush_portion, OCF_MNG_FLUSH_MAX);
+	fc->flush_portion = OCF_MAX(fc->flush_portion, OCF_MNG_FLUSH_MIN);
 
-	curr_count = MIN(fc->count - fc->iter, fc->flush_portion);
+	curr_count = OCF_MIN(fc->count - fc->iter, fc->flush_portion);
 
 	ocf_cleaner_do_flush_data_async(fc->cache,
 			&fc->flush_data[fc->iter],

--- a/src/ocf_cache.c
+++ b/src/ocf_cache.c
@@ -141,7 +141,7 @@ int ocf_cache_get_info(ocf_cache_t cache, struct ocf_cache_info *info)
 				core_runtime_meta[i].dirty_since);
 		if (core_dirty_since) {
 			dirty_since = (dirty_since ?
-				MIN(dirty_since, core_dirty_since) :
+				OCF_MIN(dirty_since, core_dirty_since) :
 				core_dirty_since);
 		}
 

--- a/src/ocf_def_priv.h
+++ b/src/ocf_def_priv.h
@@ -15,32 +15,26 @@
 #define BYTES_TO_PAGES(x)	((((uint64_t)x) + (PAGE_SIZE - 1)) / PAGE_SIZE)
 #define PAGES_TO_BYTES(x)	(((uint64_t)x) * PAGE_SIZE)
 
-#ifndef DIV_ROUND_UP
-# define DIV_ROUND_UP(x, y)			\
+#define OCF_DIV_ROUND_UP(x, y)			\
 	({					\
 		__typeof__ (x) __x = (x);	\
 		__typeof__ (y) __y = (y);	\
 		(__x + __y - 1) / __y;		\
 	})
-#endif
 
-#ifndef MAX
-# define MAX(x,y)				\
+#define OCF_MAX(x,y)				\
 	({					\
 		__typeof__ (x) __x = (x);	\
 		__typeof__ (y) __y = (y);	\
 		__x > __y ? __x : __y;		\
 	})
-#endif
 
-#ifndef MIN
-#define MIN(x,y)				\
+#define OCF_MIN(x,y)				\
 	({					\
 		__typeof__ (x) __x = (x);	\
 		__typeof__ (y) __y = (y);	\
 		__x < __y ? __x : __y;		\
 	})
-#endif
 
 #define METADATA_VERSION() ((OCF_VERSION_MAIN << 16) + \
 		(OCF_VERSION_MAJOR << 8) + OCF_VERSION_MINOR)

--- a/src/ocf_priv.h
+++ b/src/ocf_priv.h
@@ -6,6 +6,7 @@
 #define __OCF_PRIV_H__
 
 #include "ocf_env.h"
+#include "ocf_def_priv.h"
 
 #define OCF_CHECK_NULL(p) ENV_BUG_ON(!(p))
 

--- a/src/utils/utils_allocator.c
+++ b/src/utils/utils_allocator.c
@@ -170,7 +170,7 @@ struct ocf_mpool *ocf_mpool_create(struct ocf_cache *cache,
 	mpool->cache = cache;
 	mpool->flags = flags;
 
-	for (i = 0; i < min(ocf_mpool_max, mpool_max + 1); i++) {
+	for (i = 0; i < OCF_MIN(ocf_mpool_max, mpool_max + 1); i++) {
 		result = snprintf(name, sizeof(name), "%s_%u", name_perfix,
 				(1 << i));
 		if (result < 0 || result >= sizeof(name))

--- a/src/utils/utils_cache_line.h
+++ b/src/utils/utils_cache_line.h
@@ -60,7 +60,7 @@ static inline uint64_t ocf_bytes_2_lines(struct ocf_cache *cache,
 static inline uint64_t ocf_bytes_2_lines_round_up(
 		struct ocf_cache *cache, uint64_t bytes)
 {
-	return DIV_ROUND_UP(bytes, ocf_line_size(cache));
+	return OCF_DIV_ROUND_UP(bytes, ocf_line_size(cache));
 }
 
 static inline uint64_t ocf_lines_2_bytes(struct ocf_cache *cache,

--- a/src/utils/utils_io.c
+++ b/src/utils/utils_io.c
@@ -92,7 +92,7 @@ int ocf_submit_obj_discard_wait(ocf_data_obj_t obj, uint64_t addr,
 			break;
 		}
 
-		bytes = min(length, max_length);
+		bytes = OCF_MIN(length, max_length);
 
 		env_atomic_inc(&cntx.req_remaining);
 
@@ -139,7 +139,7 @@ int ocf_submit_write_zeroes_wait(ocf_data_obj_t obj, uint64_t addr,
 	while (length) {
 		env_completion_init(&cntx.complete);
 
-		bytes = MIN(length, max_length);
+		bytes = OCF_MIN(length, max_length);
 
 		ocf_io_configure(io, addr, bytes, OCF_WRITE, 0, 0);
 		ocf_io_set_cmpl(io, &cntx, NULL,

--- a/src/utils/utils_req.c
+++ b/src/utils/utils_req.c
@@ -253,7 +253,7 @@ struct ocf_request *ocf_req_new_discard(struct ocf_cache *cache,
 	struct ocf_request *req;
 
 	req = ocf_req_new_extended(cache, core_id, addr,
-			MIN(bytes, MAX_TRIM_RQ_SIZE),rw);
+			OCF_MIN(bytes, MAX_TRIM_RQ_SIZE),rw);
 
 	if (!req)
 		return NULL;

--- a/tests/ut/ocf_env/ocf_env.h
+++ b/tests/ut/ocf_env/ocf_env.h
@@ -56,8 +56,6 @@ typedef uint64_t sector_t;
 #define ENV_MEM_NOIO	1
 #define ENV_MEM_ATOMIC	2
 
-#define min(x, y) MIN(x, y)
-
 #define ENV_WARN(cond, fmt, args...) ({})
 
 #define ENV_WARN_ON(cond) ({ \


### PR DESCRIPTION
Signed-off-by: Mariusz Barczak <mariusz.barczak@intel.com>

OCF shall provides own macros for MIN, MAX, DIV_ROUND_UP. At the moment environment layer doesn't have to provide these definitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/18)
<!-- Reviewable:end -->
