### PR TITLE
Cleanup debugging macros

### DIFF
--- a/src/cleaning/alru.c
+++ b/src/cleaning/alru.c
@@ -18,30 +18,9 @@
 #define is_alru_head(x) (x == collision_table_entries)
 #define is_alru_tail(x) (x == collision_table_entries)
 
-#define OCF_CLEANING_DEBUG 0
-
-#if 1 == OCF_CLEANING_DEBUG
-
-#define OCF_DEBUG_PREFIX "[Clean] %s():%d "
-
-#define OCF_DEBUG_LOG(cache, format, ...) \
-	ocf_cache_log_prefix(cache, log_info, OCF_DEBUG_PREFIX, \
-			format"\n", __func__, __LINE__, ##__VA_ARGS__)
-
-#define OCF_DEBUG_TRACE(cache) OCF_DEBUG_LOG(cache, "")
-
-#define OCF_DEBUG_MSG(cache, msg) OCF_DEBUG_LOG(cache, "- %s", msg)
-
-#define OCF_DEBUG_PARAM(cache, format, ...) OCF_DEBUG_LOG(cache, "- "format, \
-			##__VA_ARGS__)
-
-#else
-#define OCF_DEBUG_PREFIX
-#define OCF_DEBUG_LOG(cache, format, ...)
-#define OCF_DEBUG_TRACE(cache)
-#define OCF_DEBUG_MSG(cache, msg)
-#define OCF_DEBUG_PARAM(cache, format, ...)
-#endif
+#define OCF_DEBUG_TAG "clean.alru"
+#define OCF_DEBUG 0
+#include "../ocf_debug.h"
 
 struct flush_merge_struct {
 	ocf_cache_line_t cache_line;
@@ -719,10 +698,6 @@ static int get_data_to_flush(struct flush_data *dst, uint32_t clines_no,
 
 	last_access = compute_timestamp(config);
 
-	OCF_DEBUG_PARAM(cache, "Last access=%u, timestamp=%u rel=%d",
-			last_access, policy.meta.alru.timestamp,
-			policy.meta.alru.timestamp < last_access);
-
 	while (to_flush < clines_no &&
 			more_blocks_to_flush(cache, cache_line, last_access)) {
 		if (!block_is_busy(cache, cache_line)) {
@@ -734,7 +709,11 @@ static int get_data_to_flush(struct flush_data *dst, uint32_t clines_no,
 		cache_line = policy.meta.alru.lru_prev;
 	}
 
-	OCF_DEBUG_PARAM(cache, "Collected items_to_clean=%u", to_flush);
+	OCF_DEBUG_CACHE_PARAM(cache, "Last access=%u, timestamp=%u rel=%d, "
+			"collected items to clean=%d", last_access,
+			policy.meta.alru.timestamp,
+			policy.meta.alru.timestamp < last_access,
+			to_flush);
 
 	return to_flush;
 }

--- a/src/engine/engine_d2c.c
+++ b/src/engine/engine_d2c.c
@@ -19,7 +19,7 @@ static void _ocf_d2c_completion(struct ocf_request *req, int error)
 	ocf_core_t core = &req->cache->core[req->core_id];
 	req->error = error;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		req->info.core_error = 1;
@@ -41,7 +41,7 @@ int ocf_io_d2c(struct ocf_request *req)
 	ocf_cache_t cache = req->cache;
 	ocf_core_t core = &cache->core[req->core_id];
 
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	ocf_io_start(req->io);
 

--- a/src/engine/engine_debug.h
+++ b/src/engine/engine_debug.h
@@ -10,39 +10,19 @@
 #define OCF_ENGINE_DEBUG 0
 #endif
 
-#if 1 == OCF_ENGINE_DEBUG
-
+#ifndef OCF_DEBUG_TAG
 #ifndef OCF_ENGINE_DEBUG_IO_NAME
 #define OCF_ENGINE_DEBUG_IO_NAME "null"
-#endif
-
-#define OCF_DEBUG_PREFIX "[Engine][%s] %s "
-
-#define OCF_DEBUG_LOG(cache, format, ...) \
-	ocf_cache_log_prefix(cache, log_info, OCF_DEBUG_PREFIX, \
-			format"\n", OCF_ENGINE_DEBUG_IO_NAME, __func__, \
-			##__VA_ARGS__)
-
-#define OCF_DEBUG_TRACE(cache) OCF_DEBUG_LOG(cache, "")
-
-#define OCF_DEBUG_MSG(cache, msg) OCF_DEBUG_LOG(cache, "- %s", msg)
-
-#define OCF_DEBUG_PARAM(cache, format, ...) OCF_DEBUG_LOG(cache, "- "format, \
-			##__VA_ARGS__)
-
-#define OCF_DEBUG_RQ(req, format, ...) \
-	ocf_cache_log(req->cache, log_info, "[Engine][%s][%s, %llu, %u] %s - " \
-		format"\n", OCF_ENGINE_DEBUG_IO_NAME, \
-		OCF_READ == (req)->rw ? "RD" : "WR", req->byte_position, \
-		req->byte_length, __func__, ##__VA_ARGS__)
-
+#define OCF_DEBUG_TAG "engine"
 #else
-#define OCF_DEBUG_PREFIX
-#define OCF_DEBUG_LOG(cache, format, ...)
-#define OCF_DEBUG_TRACE(cache)
-#define OCF_DEBUG_MSG(cache, msg)
-#define OCF_DEBUG_PARAM(cache, format, ...)
-#define OCF_DEBUG_RQ(req, format, ...)
+#define OCF_DEBUG_TAG "engine["OCF_ENGINE_DEBUG_IO_NAME"]"
 #endif
+#endif
+
+#ifndef OCF_DEBUG
+#define OCF_DEBUG OCF_ENGINE_DEBUG
+#endif
+
+#include "../ocf_debug.h"
 
 #endif /* ENGINE_DEBUG_H_ */

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -13,8 +13,6 @@
 #include "../utils/utils_cache_line.h"
 #include "../concurrency/ocf_concurrency.h"
 
-#define OCF_ENGINE_DEBUG 0
-
 #define OCF_ENGINE_DEBUG_IO_NAME "discard"
 #include "engine_debug.h"
 
@@ -53,7 +51,7 @@ static void _ocf_discard_core_complete(struct ocf_io *io, int error)
 {
 	struct ocf_request *req = io->priv1;
 
-	OCF_DEBUG_RQ(req, "Core DISCARD Completion");
+	OCF_DEBUG_REQ(req, "Core DISCARD Completion");
 
 	_ocf_discard_complete_req(req, error);
 
@@ -143,7 +141,7 @@ static void _ocf_discard_step_complete(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	/* Release WRITE lock of request */
 	ocf_req_unlock_wr(req);
@@ -183,7 +181,7 @@ int _ocf_discard_step_do(struct ocf_request *req)
 		OCF_METADATA_UNLOCK_WR(); /*- END Metadata WR access ---------*/
 	}
 
-	OCF_DEBUG_RQ(req, "Discard");
+	OCF_DEBUG_REQ(req, "Discard");
 	_ocf_discard_step_complete(req, 0);
 
 	/* Put OCF request - decrease reference counter */
@@ -194,7 +192,7 @@ int _ocf_discard_step_do(struct ocf_request *req)
 
 static void _ocf_discard_on_resume(struct ocf_request *req)
 {
-	OCF_DEBUG_RQ(req, "On resume");
+	OCF_DEBUG_REQ(req, "On resume");
 	ocf_engine_push_req_front(req, true);
 }
 
@@ -203,7 +201,7 @@ static int _ocf_discard_step(struct ocf_request *req)
 	int lock;
 	struct ocf_cache *cache = req->cache;
 
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	req->byte_position = SECTORS_TO_BYTES(req->discard.sector +
 			req->discard.handled);
@@ -237,10 +235,10 @@ static int _ocf_discard_step(struct ocf_request *req)
 			_ocf_discard_step_do(req);
 		} else {
 			/* WR lock was not acquired, need to wait for resume */
-			OCF_DEBUG_RQ(req, "NO LOCK")
+			OCF_DEBUG_REQ(req, "NO LOCK");
 		}
 	} else {
-		OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+		OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 		req->error |= lock;
 		_ocf_discard_finish_step(req);
 	}
@@ -252,7 +250,7 @@ static int _ocf_discard_step(struct ocf_request *req)
 
 int ocf_discard(struct ocf_request *req)
 {
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	ocf_io_start(req->io);
 

--- a/src/engine/engine_inv.c
+++ b/src/engine/engine_inv.c
@@ -27,7 +27,7 @@ static void _ocf_invalidate_req(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error)
 		ocf_engine_error(req, true, "Failed to flush metadata to cache");

--- a/src/engine/engine_ops.c
+++ b/src/engine/engine_ops.c
@@ -21,7 +21,7 @@ static void _ocf_engine_ops_complete(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		/* An error occured */
@@ -39,7 +39,7 @@ int ocf_engine_ops(struct ocf_request *req)
 {
 	struct ocf_cache *cache = req->cache;
 
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	/* Get OCF request - increase reference counter */
 	ocf_req_get(req);

--- a/src/engine/engine_pt.c
+++ b/src/engine/engine_pt.c
@@ -24,7 +24,7 @@ static void _ocf_read_pt_complete(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		req->info.core_error = 1;
@@ -47,7 +47,7 @@ static inline void _ocf_read_pt_submit(struct ocf_request *req)
 
 	env_atomic_set(&req->req_remaining, 1); /* Core device IO */
 
-	OCF_DEBUG_RQ(req, "Submit");
+	OCF_DEBUG_REQ(req, "Submit");
 
 	/* Core read */
 	ocf_submit_volume_req(&cache->core[req->core_id].volume, req,
@@ -74,7 +74,7 @@ int ocf_read_pt_do(struct ocf_request *req)
 	}
 
 	if (req->info.re_part) {
-		OCF_DEBUG_RQ(req, "Re-Part");
+		OCF_DEBUG_REQ(req, "Re-Part");
 
 		OCF_METADATA_LOCK_WR();
 
@@ -111,7 +111,7 @@ int ocf_read_pt(struct ocf_request *req)
 	int lock = OCF_LOCK_NOT_ACQUIRED;
 	struct ocf_cache *cache = req->cache;
 
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	ocf_io_start(req->io);
 
@@ -157,10 +157,10 @@ int ocf_read_pt(struct ocf_request *req)
 				ocf_read_pt_do(req);
 			} else {
 				/* WR lock was not acquired, need to wait for resume */
-				OCF_DEBUG_RQ(req, "NO LOCK");
+				OCF_DEBUG_REQ(req, "NO LOCK");
 			}
 		} else {
-			OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+			OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 			req->complete(req, lock);
 			ocf_req_put(req);
 		}

--- a/src/engine/engine_rd.c
+++ b/src/engine/engine_rd.c
@@ -35,7 +35,7 @@ static void _ocf_read_generic_hit_complete(struct ocf_request *req, int error)
 	 * sub-request to complete
 	 */
 	if (env_atomic_dec_return(&req->req_remaining) == 0) {
-		OCF_DEBUG_RQ(req, "HIT completion");
+		OCF_DEBUG_REQ(req, "HIT completion");
 
 		if (req->error) {
 			env_atomic_inc(&req->cache->core[req->core_id].
@@ -68,7 +68,7 @@ static void _ocf_read_generic_miss_complete(struct ocf_request *req, int error)
 	 * sub-request to complete
 	 */
 	if (env_atomic_dec_return(&req->req_remaining) == 0) {
-		OCF_DEBUG_RQ(req, "MISS completion");
+		OCF_DEBUG_REQ(req, "MISS completion");
 
 		if (req->error) {
 			/*
@@ -145,7 +145,7 @@ static int _ocf_read_generic_do(struct ocf_request *req)
 		/* Miss can be handled only on write locks.
 		 * Need to switch to PT
 		 */
-		OCF_DEBUG_RQ(req, "Switching to PT");
+		OCF_DEBUG_REQ(req, "Switching to PT");
 		ocf_read_pt_do(req);
 		return 0;
 	}
@@ -177,7 +177,7 @@ static int _ocf_read_generic_do(struct ocf_request *req)
 	}
 
 	if (req->info.re_part) {
-		OCF_DEBUG_RQ(req, "Re-Part");
+		OCF_DEBUG_REQ(req, "Re-Part");
 
 		OCF_METADATA_LOCK_WR();
 
@@ -189,7 +189,7 @@ static int _ocf_read_generic_do(struct ocf_request *req)
 		OCF_METADATA_UNLOCK_WR();
 	}
 
-	OCF_DEBUG_RQ(req, "Submit");
+	OCF_DEBUG_REQ(req, "Submit");
 
 	/* Submit IO */
 	if (ocf_engine_is_hit(req))
@@ -293,13 +293,13 @@ int ocf_read_generic(struct ocf_request *req)
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* Lock was not acquired, need to wait for resume */
-				OCF_DEBUG_RQ(req, "NO LOCK");
+				OCF_DEBUG_REQ(req, "NO LOCK");
 			} else {
 				/* Lock was acquired can perform IO */
 				_ocf_read_generic_do(req);
 			}
 		} else {
-			OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+			OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 			req->complete(req, lock);
 			ocf_req_put(req);
 		}

--- a/src/engine/engine_wa.c
+++ b/src/engine/engine_wa.c
@@ -31,7 +31,7 @@ static void _ocf_read_wa_complete(struct ocf_request *req, int error)
 	/* Complete request */
 	req->complete(req, req->error);
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	/* Release OCF request */
 	ocf_req_put(req);
@@ -68,7 +68,7 @@ int ocf_write_wa(struct ocf_request *req)
 
 		/* There is no mapped cache line, write directly into core */
 
-		OCF_DEBUG_RQ(req, "Submit");
+		OCF_DEBUG_REQ(req, "Submit");
 
 		/* Submit write IO to the core */
 		env_atomic_set(&req->req_remaining, 1);

--- a/src/engine/engine_wb.c
+++ b/src/engine/engine_wb.c
@@ -70,7 +70,7 @@ static int ocf_write_wb_do_flush_metadata(struct ocf_request *req)
 	env_atomic_set(&req->req_remaining, 1); /* One core IO */
 
 	if (req->info.flush_metadata) {
-		OCF_DEBUG_RQ(req, "Flush metadata");
+		OCF_DEBUG_REQ(req, "Flush metadata");
 		ocf_metadata_flush_do_asynch(cache, req,
 				_ocf_write_wb_io_flush_metadata);
 	}
@@ -96,7 +96,7 @@ static void _ocf_write_wb_complete(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		ocf_engine_error(req, true, "Failed to write data to cache");
@@ -126,7 +126,7 @@ static inline void _ocf_write_wb_submit(struct ocf_request *req)
 	 */
 
 	if (req->info.re_part) {
-		OCF_DEBUG_RQ(req, "Re-Part");
+		OCF_DEBUG_REQ(req, "Re-Part");
 
 		OCF_METADATA_LOCK_WR();
 
@@ -138,7 +138,7 @@ static inline void _ocf_write_wb_submit(struct ocf_request *req)
 		OCF_METADATA_UNLOCK_WR();
 	}
 
-	OCF_DEBUG_RQ(req, "Submit Data");
+	OCF_DEBUG_REQ(req, "Submit Data");
 
 	/* Data IO */
 	ocf_submit_cache_reqs(cache, req->map, req, OCF_WRITE,
@@ -217,12 +217,12 @@ int ocf_write_wb(struct ocf_request *req)
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* WR lock was not acquired, need to wait for resume */
-				OCF_DEBUG_RQ(req, "NO LOCK");
+				OCF_DEBUG_REQ(req, "NO LOCK");
 			} else {
 				ocf_write_wb_do(req);
 			}
 		} else {
-			OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+			OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 			req->complete(req, lock);
 			ocf_req_put(req);
 		}

--- a/src/engine/engine_wi.c
+++ b/src/engine/engine_wi.c
@@ -85,7 +85,7 @@ static void _ocf_write_wi_core_complete(struct ocf_request *req, int error)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		ocf_req_unlock_wr(req);
@@ -108,7 +108,7 @@ static int _ocf_write_wi_do(struct ocf_request *req)
 
 	env_atomic_set(&req->req_remaining, 1); /* One core IO */
 
-	OCF_DEBUG_RQ(req, "Submit");
+	OCF_DEBUG_REQ(req, "Submit");
 
 	/* Submit write IO to the core */
 	ocf_submit_volume_req(&cache->core[req->core_id].volume, req,
@@ -127,7 +127,7 @@ static int _ocf_write_wi_do(struct ocf_request *req)
 
 static void _ocf_write_wi_on_resume(struct ocf_request *req)
 {
-	OCF_DEBUG_RQ(req, "On resume");
+	OCF_DEBUG_REQ(req, "On resume");
 	ocf_engine_push_req_front(req, true);
 }
 
@@ -141,7 +141,7 @@ int ocf_write_wi(struct ocf_request *req)
 	int lock = OCF_LOCK_NOT_ACQUIRED;
 	struct ocf_cache *cache = req->cache;
 
-	OCF_DEBUG_TRACE(req->cache);
+	OCF_DEBUG_CACHE_TRACE(req->cache);
 
 	ocf_io_start(req->io);
 
@@ -171,10 +171,10 @@ int ocf_write_wi(struct ocf_request *req)
 			_ocf_write_wi_do(req);
 		} else {
 			/* WR lock was not acquired, need to wait for resume */
-			OCF_DEBUG_RQ(req, "NO LOCK");
+			OCF_DEBUG_REQ(req, "NO LOCK");
 		}
 	} else {
-		OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+		OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 		req->complete(req, lock);
 		ocf_req_put(req);
 	}

--- a/src/engine/engine_wt.c
+++ b/src/engine/engine_wt.c
@@ -23,7 +23,7 @@ static void _ocf_write_wt_req_complete(struct ocf_request *req)
 	if (env_atomic_dec_return(&req->req_remaining))
 		return;
 
-	OCF_DEBUG_RQ(req, "Completion");
+	OCF_DEBUG_REQ(req, "Completion");
 
 	if (req->error) {
 		/* An error occured */
@@ -75,7 +75,7 @@ static inline void _ocf_write_wt_submit(struct ocf_request *req)
 	struct ocf_cache *cache = req->cache;
 
 	/* Submit IOs */
-	OCF_DEBUG_RQ(req, "Submit");
+	OCF_DEBUG_REQ(req, "Submit");
 
 	/* Calculate how many IOs need to be submited */
 	env_atomic_set(&req->req_remaining, ocf_engine_io_count(req)); /* Cache IO */
@@ -123,7 +123,7 @@ static void _ocf_write_wt_update_bits(struct ocf_request *req)
 	}
 
 	if (req->info.re_part) {
-		OCF_DEBUG_RQ(req, "Re-Part");
+		OCF_DEBUG_REQ(req, "Re-Part");
 
 		OCF_METADATA_LOCK_WR();
 
@@ -211,12 +211,12 @@ int ocf_write_wt(struct ocf_request *req)
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* WR lock was not acquired, need to wait for resume */
-				OCF_DEBUG_RQ(req, "NO LOCK");
+				OCF_DEBUG_REQ(req, "NO LOCK");
 			} else {
 				_ocf_write_wt_do(req);
 			}
 		} else {
-			OCF_DEBUG_RQ(req, "LOCK ERROR %d\n", lock);
+			OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 			req->complete(req, lock);
 			ocf_req_put(req);
 		}

--- a/src/engine/engine_zero.c
+++ b/src/engine/engine_zero.c
@@ -158,7 +158,7 @@ void ocf_engine_zero_line(struct ocf_request *req)
 		ENV_BUG_ON(lock != OCF_LOCK_ACQUIRED);
 		ocf_engine_push_req_front_if(req, &_io_if_ocf_zero_do, true);
 	} else {
-		OCF_DEBUG_RQ(req, "LOCK ERROR %d", lock);
+		OCF_DEBUG_REQ(req, "LOCK ERROR %d", lock);
 		req->complete(req, lock);
 		ocf_req_put(req);
 	}

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -12,14 +12,9 @@
 #include "../utils/utils_io.h"
 #include "../utils/utils_cache_line.h"
 
-#define OCF_METADATA_DEBUG 0
-
-#if 1 == OCF_METADATA_DEBUG
-#define OCF_DEBUG_TRACE(cache) \
-	ocf_cache_log(cache, log_info, "[Metadata][Hash] %s\n", __func__)
-#else
-#define OCF_DEBUG_TRACE(cache)
-#endif
+#define OCF_DEBUG_TAG "meta.hash"
+#define OCF_DEBUG 0
+#include "../ocf_debug.h"
 
 int ocf_metadata_init(struct ocf_cache *cache,
 		ocf_cache_line_size_t cache_line_size)
@@ -28,7 +23,7 @@ int ocf_metadata_init(struct ocf_cache *cache,
 			&cache->metadata.iface;
 	int ret;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ENV_BUG_ON(cache->metadata.iface_priv);
 
@@ -48,26 +43,26 @@ int ocf_metadata_init_variable_size(struct ocf_cache *cache, uint64_t device_siz
 		ocf_cache_line_size_t cache_line_size,
 		ocf_metadata_layout_t layout)
 {
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 	return cache->metadata.iface.init_variable_size(cache, device_size,
 			cache_line_size, layout);
 }
 
 void ocf_metadata_init_freelist_partition(struct ocf_cache *cache)
 {
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 	cache->metadata.iface.layout_iface->init_freelist(cache);
 }
 
 void ocf_metadata_init_hash_table(struct ocf_cache *cache)
 {
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 	cache->metadata.iface.init_hash_table(cache);
 }
 
 void ocf_metadata_deinit(struct ocf_cache *cache)
 {
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	if (cache->metadata.iface.deinit) {
 		cache->metadata.iface.deinit(cache);
@@ -78,7 +73,7 @@ void ocf_metadata_deinit(struct ocf_cache *cache)
 
 void ocf_metadata_deinit_variable_size(struct ocf_cache *cache)
 {
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	if (cache->metadata.iface.deinit_variable_size)
 		cache->metadata.iface.deinit_variable_size(cache);
@@ -314,7 +309,7 @@ void ocf_metadata_load_properties(ocf_volume_t volume,
 {
 	int result;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	result = ocf_metadata_read_sb(volume->cache->owner, volume,
 			ocf_metadata_load_properties_cmpl, cmpl, priv);

--- a/src/metadata/metadata_hash.c
+++ b/src/metadata/metadata_hash.c
@@ -12,19 +12,9 @@
 #include "../utils/utils_cache_line.h"
 #include "../ocf_def_priv.h"
 
-#define OCF_METADATA_HASH_DEBUG 0
-
-#if 1 == OCF_METADATA_HASH_DEBUG
-#define OCF_DEBUG_TRACE(cache) \
-	ocf_cache_log(cache, log_info, "[Metadata][Hash] %s\n", __func__)
-
-#define OCF_DEBUG_PARAM(cache, format, ...) \
-	ocf_cache_log(cache, log_info, "[Metadata][Hash] %s - "format"\n", \
-			__func__, ##__VA_ARGS__)
-#else
-#define OCF_DEBUG_TRACE(cache)
-#define OCF_DEBUG_PARAM(cache, format, ...)
-#endif
+#define OCF_DEBUG_TAG "meta.hash"
+#define OCF_DEBUG 0
+#include "../ocf_debug.h"
 
 #define METADATA_MEM_POOL(ctrl, section) ctrl->raw_desc[section].mem_pool
 
@@ -228,7 +218,7 @@ static int ocf_metadata_hash_calculate_metadata_size(
 	ocf_cache_line_t count_pages;
 	uint32_t i;
 
-	OCF_DEBUG_PARAM(cache, "Cache lines = %lld", cache_lines);
+	OCF_DEBUG_CACHE_PARAM(cache, "Cache lines = %lld", cache_lines);
 
 	lowest_diff = cache_lines;
 
@@ -297,8 +287,8 @@ static int ocf_metadata_hash_calculate_metadata_size(
 		/* Update new value of cache lines */
 		cache_lines += diff_lines;
 
-		OCF_DEBUG_PARAM(cache, "Diff pages = %lld", diff_lines);
-		OCF_DEBUG_PARAM(cache, "Cache lines = %lld", cache_lines);
+		OCF_DEBUG_CACHE_PARAM(cache, "Diff pages = %lld", diff_lines);
+		OCF_DEBUG_CACHE_PARAM(cache, "Cache lines = %lld", cache_lines);
 
 		i_diff++;
 
@@ -306,7 +296,7 @@ static int ocf_metadata_hash_calculate_metadata_size(
 
 	ctrl->count_pages = count_pages;
 	ctrl->cachelines = cache_lines;
-	OCF_DEBUG_PARAM(cache, "Cache lines = %u", ctrl->cachelines);
+	OCF_DEBUG_CACHE_PARAM(cache, "Cache lines = %u", ctrl->cachelines);
 
 	if (ctrl->device_lines < ctrl->cachelines)
 		return -1;
@@ -327,7 +317,7 @@ static const char * const ocf_metadata_hash_raw_names[] = {
 		[metadata_segment_core_runtime]		= "Core runtime",
 		[metadata_segment_core_uuid]		= "Core UUID",
 };
-#if 1 == OCF_METADATA_HASH_DEBUG
+#if 1 == OCF_DEBUG
 /*
  * Debug info functions prints metadata and raw containers information
  */
@@ -342,20 +332,20 @@ static void ocf_metadata_hash_raw_info(struct ocf_cache *cache,
 	for (i = 0; i < metadata_segment_max; i++) {
 		struct ocf_metadata_raw *raw = &(ctrl->raw_desc[i]);
 
-		OCF_DEBUG_PARAM(cache, "Raw : name            = %s",
+		OCF_DEBUG_CACHE_PARAM(cache, "Raw : name            = %s",
 				ocf_metadata_hash_raw_names[i]);
-		OCF_DEBUG_PARAM(cache, "    : metadata type   = %u", i);
-		OCF_DEBUG_PARAM(cache, "    : raw type        = %u",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : metadata type   = %u", i);
+		OCF_DEBUG_CACHE_PARAM(cache, "    : raw type        = %u",
 				raw->raw_type);
-		OCF_DEBUG_PARAM(cache, "    : entry size      = %u",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : entry size      = %u",
 				raw->entry_size);
-		OCF_DEBUG_PARAM(cache, "    : entries         = %llu",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : entries         = %llu",
 				raw->entries);
-		OCF_DEBUG_PARAM(cache, "    : entries in page = %u",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : entries in page = %u",
 				raw->entries_in_page);
-		OCF_DEBUG_PARAM(cache, "    : page offset     = %llu",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : page offset     = %llu",
 				raw->ssd_pages_offset);
-		OCF_DEBUG_PARAM(cache, "    : pages           = %llu",
+		OCF_DEBUG_CACHE_PARAM(cache, "    : pages           = %llu",
 				raw->ssd_pages);
 	}
 
@@ -375,7 +365,7 @@ static void ocf_metadata_hash_raw_info(struct ocf_cache *cache,
 
 		}
 
-		OCF_DEBUG_PARAM(cache, "%s capacity %llu %s",
+		OCF_DEBUG_CACHE_PARAM(cache, "%s capacity %llu %s",
 			ocf_metadata_hash_raw_names[i], capacity, unit);
 	}
 }
@@ -395,7 +385,7 @@ static void ocf_metadata_hash_deinit_variable_size(struct ocf_cache *cache)
 	struct ocf_metadata_hash_ctrl *ctrl = (struct ocf_metadata_hash_ctrl *)
 			cache->metadata.iface_priv;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	/*
 	 * De initialize RAW types
@@ -419,9 +409,9 @@ static inline void ocf_metadata_config_init(struct ocf_cache *cache,
 	settings->sector_start = 0;
 	settings->sector_end = settings->sector_count - 1;
 
-	OCF_DEBUG_PARAM(cache, "Cache line size = %lu, bits count = %llu, "
-			"status size = %lu",
-			settings->size, settings->sector_count,
+	OCF_DEBUG_CACHE_PARAM(cache, "Cache line size = %lu, bits count = %llu"
+			", status size = %lu", settings->size,
+			settings->sector_count,
 			ocf_metadata_status_sizeof(settings));
 }
 
@@ -455,7 +445,7 @@ static int ocf_metadata_hash_init(struct ocf_cache *cache,
 	uint32_t page = 0;
 	int result = 0;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ENV_WARN_ON(cache->metadata.iface_priv);
 
@@ -546,7 +536,7 @@ static int ocf_metadata_hash_init_variable_size(struct ocf_cache *cache,
 	struct ocf_cache_line_settings *settings =
 		(struct ocf_cache_line_settings *)&cache->metadata.settings;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ENV_WARN_ON(!cache->metadata.iface_priv);
 
@@ -591,10 +581,12 @@ static int ocf_metadata_hash_init_variable_size(struct ocf_cache *cache,
 		return -1;
 	}
 
-	OCF_DEBUG_PARAM(cache, "Metadata begin pages = %u", ctrl->start_page);
-	OCF_DEBUG_PARAM(cache, "Metadata count pages = %u", ctrl->count_pages);
-	OCF_DEBUG_PARAM(cache, "Metadata end pages = %u", ctrl->start_page
-			+ ctrl->count_pages);
+	OCF_DEBUG_CACHE_PARAM(cache, "Metadata begin pages = %u",
+			ctrl->start_page);
+	OCF_DEBUG_CACHE_PARAM(cache, "Metadata count pages = %u",
+			ctrl->count_pages);
+	OCF_DEBUG_CACHE_PARAM(cache, "Metadata end pages = %u",
+			ctrl->start_page + ctrl->count_pages);
 
 	/*
 	 * Initialize all dynamic size  RAW types
@@ -824,7 +816,7 @@ static ocf_cache_line_t ocf_metadata_hash_pages(struct ocf_cache *cache)
 {
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -839,7 +831,7 @@ static ocf_cache_line_t ocf_metadata_hash_cachelines(
 {
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -852,7 +844,7 @@ static size_t ocf_metadata_hash_size_of(struct ocf_cache *cache)
 	size_t size = 0;
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -889,7 +881,7 @@ static int ocf_metadata_hash_load_superblock(struct ocf_cache *cache)
 	struct ocf_metadata_uuid *muuid;
 	struct ocf_volume_uuid uuid;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 	ENV_BUG_ON(!ctrl);
@@ -1014,7 +1006,7 @@ static int ocf_metadata_hash_flush_superblock(struct ocf_cache *cache)
 	struct ocf_metadata_hash_ctrl *ctrl;
 	struct ocf_superblock_config *superblock;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1071,7 +1063,7 @@ static int ocf_metadata_hash_set_shutdown_status(
 	struct ocf_metadata_hash_ctrl *ctrl;
 	struct ocf_superblock_config *superblock;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	/*
 	 * Get metadata hash service control structure
@@ -1100,7 +1092,7 @@ static uint64_t ocf_metadata_hash_get_reserved_lba(
 {
 	struct ocf_metadata_hash_ctrl *ctrl;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 	return ctrl->raw_desc[metadata_segment_reserved].ssd_pages_offset *
@@ -1121,7 +1113,7 @@ static int ocf_metadata_hash_flush_all(struct ocf_cache *cache)
 	int result = 0;
 	uint32_t i = 0;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1181,7 +1173,7 @@ static void ocf_metadata_hash_flush(struct ocf_cache *cache,
 	int result = 0;
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1211,7 +1203,7 @@ static void ocf_metadata_hash_flush_mark(struct ocf_cache *cache,
 {
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1235,7 +1227,7 @@ static void ocf_metadata_hash_flush_do_asynch(struct ocf_cache *cache,
 	int result = 0;
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1266,7 +1258,7 @@ static int ocf_metadata_hash_load_all(struct ocf_cache *cache)
 	int result = 0, i = 0;
 	uint32_t checksum;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1430,7 +1422,7 @@ static int _ocf_metadata_hash_load_recovery_legacy(
 	int result = 0;
 	struct ocf_metadata_hash_ctrl *ctrl = NULL;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	ctrl = (struct ocf_metadata_hash_ctrl *) cache->metadata.iface_priv;
 
@@ -1516,7 +1508,7 @@ static int _ocf_metadata_hash_load_recovery_atomic(
 {
 	int result = 0;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 	/* Collision table to get mapping cache line to HDD sector*/
 	result |= metadata_io_read_i_atomic(cache,
@@ -1540,7 +1532,7 @@ static int ocf_metadata_hash_load_recovery(struct ocf_cache *cache)
 	int result = 0;
 	bool rebuild_dirty_only;
 
-	OCF_DEBUG_TRACE(cache);
+	OCF_DEBUG_CACHE_TRACE(cache);
 
 
 	if (ocf_volume_is_atomic(&cache->device->volume)) {

--- a/src/metadata/metadata_raw_atomic.c
+++ b/src/metadata/metadata_raw_atomic.c
@@ -12,24 +12,9 @@
 #include "../utils/utils_cache_line.h"
 #include "../ocf_def_priv.h"
 
-#define OCF_METADATA_RAW_ATOMIC_DEBUG 0
-
-#if 1 == OCF_METADATA_RAW_ATOMIC_DEBUG
-#define OCF_DEBUG_TRACE(cache) \
-	ocf_cache_log(cache, log_info, "[Metadata][Raw][Atomic] %s\n", __func__)
-
-#define OCF_DEBUG_MSG(cache, msg) \
-	ocf_cache_log(cache, log_info, "[Metadata][Raw][Atomic] %s - %s\n", \
-			__func__, msg)
-
-#define OCF_DEBUG_PARAM(cache, format, ...) \
-	ocf_cache_log(cache, log_info, "[Metadata][Raw][Atomic] %s - "format"\n", \
-			__func__, ##__VA_ARGS__)
-#else
-#define OCF_DEBUG_TRACE(cache)
-#define OCF_DEBUG_MSG(cache, msg)
-#define OCF_DEBUG_PARAM(cache, format, ...)
-#endif
+#define OCF_DEBUG_TAG "meta.raw.atomic"
+#define OCF_DEBUG 0
+#include "../ocf_debug.h"
 
 struct _raw_atomic_flush_ctx {
 	struct ocf_request *req;
@@ -50,8 +35,6 @@ static void _raw_atomic_io_discard_cmpl(struct _raw_atomic_flush_ctx *ctx,
 		ocf_metadata_error(ctx->req->cache);
 
 	/* Call metadata flush completed call back */
-	OCF_DEBUG_MSG(cache, "Asynchronous flushing complete");
-
 	ctx->complete(ctx->req, ctx->req->error);
 
 	env_free(ctx);
@@ -77,8 +60,8 @@ static int _raw_atomic_io_discard_do(struct ocf_cache *cache, void *context,
 		return req->error;
 	}
 
-	OCF_DEBUG_PARAM(cache, "Page to flushing = %u, count of pages = %u",
-			start_line, len);
+	OCF_DEBUG_CACHE_PARAM(cache, "Page to flushing = %llu,"
+			" count of pages = %u", start_addr, len);
 
 	env_atomic_inc(&ctx->flush_req_cnt);
 

--- a/src/ocf_debug.h
+++ b/src/ocf_debug.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright(c) 2012-2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef OCF_DEBUG_H
+#define OCF_DEBUG_H
+
+#ifndef OCF_DEBUG_TAG
+#define OCF_DEBUG_TAG "debug"
+#endif
+
+#ifndef OCF_DEBUG
+#define OCF_DEBUG 0
+#endif
+
+#if OCF_DEBUG == 1
+
+/* helpers */
+#define _OCF_DEBUG_LOG(log_prefix_func, ctx, prefix, format, ...) \
+               log_prefix_func(ctx, log_debug, prefix OCF_DEBUG_TAG ".%s()", \
+                               format"\n", __func__, ##__VA_ARGS__)
+
+#define _OCF_DEBUG_TRACE(log_prefix_func, ctx, prefix) \
+               _OCF_DEBUG_LOG(log_prefix_func, ctx, prefix, ":%d", __LINE__)
+
+#define _OCF_DEBUG_MSG(log_prefix_func, ctx, prefix, msg) \
+               _OCF_DEBUG_LOG(log_prefix_func, ctx, prefix, ": %s", msg)
+
+#define _OCF_DEBUG_PARAM(log_prefix_func, ctx, prefix, format, ...) \
+               _OCF_DEBUG_LOG(log_prefix_func, ctx, prefix, ": "format, \
+				##__VA_ARGS__)
+
+/* ocf_ctx */
+#define OCF_DEBUG_TRACE(ctx) \
+               _OCF_DEBUG_TRACE(ocf_log_prefix, ctx, "")
+
+#define OCF_DEBUG_MSG(ctx, msg) \
+               _OCF_DEBUG_MSG(ocf_log_prefix, ctx, "", msg)
+
+#define OCF_DEBUG_PARAM(ctx, format, ...) \
+               _OCF_DEBUG_PARAM(ocf_log_prefix, ctx, "", format, ##__VA_ARGS__)
+
+/* ocf_cache */
+#define OCF_DEBUG_CACHE_TRACE(cache) \
+               _OCF_DEBUG_TRACE(ocf_cache_log_prefix, cache, ".")
+
+#define OCF_DEBUG_CACHE_MSG(cache, msg) \
+               _OCF_DEBUG_MSG(ocf_cache_log_prefix, cache, ".", msg)
+
+#define OCF_DEBUG_CACHE_PARAM(cache, format, ...) \
+               _OCF_DEBUG_PARAM(ocf_cache_log_prefix, cache, ".", format, \
+                               ##__VA_ARGS__)
+
+/* ocf_core */
+#define OCF_DEBUG_CORE_TRACE(core) \
+               _OCF_DEBUG_TRACE(ocf_core_log_prefix, core, ".")
+
+#define OCF_DEBUG_CORE_MSG(core, msg) \
+               _OCF_DEBUG_MSG(ocf_core_log_prefix, core, ".", msg)
+
+#define OCF_DEBUG_CORE_PARAM(core, format, ...) \
+               _OCF_DEBUG_PARAM(ocf_core_log_prefix, core, ".", format, \
+                               ##__VA_ARGS__)
+
+/* other */
+#define OCF_DEBUG_REQ(req, format, ...) \
+               ocf_cache_log_prefix(req->cache, log_debug, \
+                       "."OCF_DEBUG_TAG".%s(%s, %llu, %u): ", format, \
+                       __func__, OCF_READ == (req)->rw ? "rd" : "wr", \
+                       req->byte_position, req->byte_length, ##__VA_ARGS__)
+
+#else
+#define OCF_DEBUG_TRACE(ctx)
+#define OCF_DEBUG_MSG(ctx, msg)
+#define OCF_DEBUG_PARAM(ctx, format, ...)
+#define OCF_DEBUG_CACHE_TRACE(cache)
+#define OCF_DEBUG_CACHE_MSG(cache, msg)
+#define OCF_DEBUG_CACHE_PARAM(cache, format, ...)
+#define OCF_DEBUG_CORE_TRACE(core)
+#define OCF_DEBUG_CORE_MSG(core, msg)
+#define OCF_DEBUG_CORE_PARAM(core, format, ...)
+#define OCF_DEBUG_REQ(rq, format, ...)
+#endif
+
+#endif /* OCF_DEBUG_H */
+


### PR DESCRIPTION
- create one file that contains debug macros

- format debug tags to new printing style:
> cache1.utils.req.ocf_req_new():182
> cache1.clean.alru.is_cleanup_possible(): IO activity detected
> cache1.meta.volatile._raw_dynamic_flush_all_fill(): Zero fill, Page = 4095

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/20)
<!-- Reviewable:end -->
