### PR TITLE
Fix OCF compilation - use new macro name

### DIFF
--- a/src/metadata/metadata_hash.c
+++ b/src/metadata/metadata_hash.c
@@ -81,7 +81,7 @@ static ocf_cache_line_t ocf_metadata_hash_get_entires(
 		return cache_lines;
 
 	case metadata_segment_hash:
-		return DIV_ROUND_UP(cache_lines / 4, OCF_HASH_PRIME) *
+		return OCF_DIV_ROUND_UP(cache_lines / 4, OCF_HASH_PRIME) *
 				OCF_HASH_PRIME - 1;
 
 	case metadata_segment_sb_config:


### PR DESCRIPTION
This looks like during change from DIV_ROUND_UP to OCF_DIV_ROUND_UP
this one occurrence has been missed.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/21)
<!-- Reviewable:end -->
