### PR TITLE
Add more missing io_set_queue

### DIFF
--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -77,6 +77,7 @@ static int _ocf_discard_core(struct ocf_request *req)
 
 	ocf_io_set_cmpl(io, req, NULL, _ocf_discard_core_complete);
 	ocf_io_set_data(io, req->data, 0);
+	ocf_io_set_queue(io, req->io_queue);
 
 	ocf_dobj_submit_discard(io);
 
@@ -113,6 +114,7 @@ static int _ocf_discard_flush_cache(struct ocf_request *req)
 
 	ocf_io_configure(io, 0, 0, OCF_WRITE, 0, 0);
 	ocf_io_set_cmpl(io, req, NULL, _ocf_discard_cache_flush_complete);
+	ocf_io_set_queue(io, req->io_queue);
 
 	ocf_dobj_submit_flush(io);
 


### PR DESCRIPTION
Propagate id of ocf_queue for discard io

This resolves the issue of
  bottom adapter always getting an ocf_io with io_queue = 0,
  no matter from which queue function to bottom adapter was called

This is a follow up on e69894e398ebdf2ecb2a61d4ff6cb9076507884e

Signed-off-by: Vitaliy Mysak <vitaliy.mysak@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/32)
<!-- Reviewable:end -->
