### PR TITLE
Enable passing priv to logger during context initialization

### DIFF
--- a/inc/ocf_ctx.h
+++ b/inc/ocf_ctx.h
@@ -240,17 +240,31 @@ struct ocf_metadata_updater_ops {
  * @brief OCF context specific operation
  */
 struct ocf_ctx_ops {
-	/**
-	 * @brief The name of the environment which provides platform
-	 * interface for cache engine
-	 */
+	/* Context data operations */
+	struct ocf_data_ops data;
+
+	/* Queue operations */
+	struct ocf_queue_ops queue;
+
+	/* Cleaner operations */
+	struct ocf_cleaner_ops cleaner;
+
+	/* Metadata updater operations */
+	struct ocf_metadata_updater_ops metadata_updater;
+
+	/* Logger operations */
+	struct ocf_logger_ops logger;
+};
+
+struct ocf_ctx_config {
+	/* Context name */
 	const char *name;
 
-	struct ocf_data_ops data;
-	struct ocf_queue_ops queue;
-	struct ocf_cleaner_ops cleaner;
-	struct ocf_metadata_updater_ops metadata_updater;
-	struct ocf_logger_ops logger;
+	/* Context operations */
+	const struct ocf_ctx_ops ops;
+
+	/* Context logger priv */
+	void *logger_priv;
 };
 
 /**
@@ -322,7 +336,7 @@ int ocf_ctx_data_obj_create(ocf_ctx_t ctx, ocf_data_obj_t *obj,
  *
  * @return Zero when success, otherwise an error
  */
-int ocf_ctx_init(ocf_ctx_t *ctx, const struct ocf_ctx_ops *ops);
+int ocf_ctx_init(ocf_ctx_t *ctx, const struct ocf_ctx_config *cfg);
 
 /**
  * @brief De-Initialize OCF context

--- a/src/ocf_ctx.c
+++ b/src/ocf_ctx.c
@@ -113,13 +113,13 @@ int ocf_ctx_data_obj_create(ocf_ctx_t ctx, ocf_data_obj_t *obj,
 /*
  *
  */
-int ocf_ctx_init(ocf_ctx_t *ctx, const struct ocf_ctx_ops *ops)
+int ocf_ctx_init(ocf_ctx_t *ctx, const struct ocf_ctx_config *cfg)
 {
 	ocf_ctx_t ocf_ctx;
 	int ret;
 
 	OCF_CHECK_NULL(ctx);
-	OCF_CHECK_NULL(ops);
+	OCF_CHECK_NULL(cfg);
 
 	ocf_ctx = env_zalloc(sizeof(*ocf_ctx), ENV_MEM_NORMAL);
 	if (!ocf_ctx)
@@ -130,8 +130,10 @@ int ocf_ctx_init(ocf_ctx_t *ctx, const struct ocf_ctx_ops *ops)
 	if (ret)
 		goto err_ctx;
 
-	ocf_ctx->ctx_ops = ops;
-	ocf_ctx->logger.ops = &ops->logger;
+	ocf_ctx->ops = &cfg->ops;
+	ocf_ctx->cfg = cfg;
+
+	ocf_logger_init(&ocf_ctx->logger, &cfg->ops.logger, cfg->logger_priv);
 
 	ret = ocf_logger_open(&ocf_ctx->logger);
 	if (ret)

--- a/src/ocf_ctx_priv.h
+++ b/src/ocf_ctx_priv.h
@@ -16,7 +16,8 @@
  * @brief OCF main control structure
  */
 struct ocf_ctx {
-	const struct ocf_ctx_ops *ctx_ops;
+	const struct ocf_ctx_ops *ops;
+	const struct ocf_ctx_config *cfg;
 	struct ocf_logger logger;
 	struct ocf_data_obj_type *data_obj_type[OCF_DATA_OBJ_TYPE_MAX];
 	env_mutex lock;
@@ -50,34 +51,34 @@ struct ocf_ctx {
  */
 static inline void *ctx_data_alloc(ocf_ctx_t ctx, uint32_t pages)
 {
-	return ctx->ctx_ops->data.alloc(pages);
+	return ctx->ops->data.alloc(pages);
 }
 
 static inline void ctx_data_free(ocf_ctx_t ctx, ctx_data_t *data)
 {
-	ctx->ctx_ops->data.free(data);
+	ctx->ops->data.free(data);
 }
 
 static inline int ctx_data_mlock(ocf_ctx_t ctx, ctx_data_t *data)
 {
-	return ctx->ctx_ops->data.mlock(data);
+	return ctx->ops->data.mlock(data);
 }
 
 static inline void ctx_data_munlock(ocf_ctx_t ctx, ctx_data_t *data)
 {
-	ctx->ctx_ops->data.munlock(data);
+	ctx->ops->data.munlock(data);
 }
 
 static inline uint32_t ctx_data_rd(ocf_ctx_t ctx, void *dst,
 		ctx_data_t *src, uint32_t size)
 {
-	return ctx->ctx_ops->data.read(dst, src, size);
+	return ctx->ops->data.read(dst, src, size);
 }
 
 static inline uint32_t ctx_data_wr(ocf_ctx_t ctx, ctx_data_t *dst,
 		const void *src, uint32_t size)
 {
-	return ctx->ctx_ops->data.write(dst, src, size);
+	return ctx->ops->data.write(dst, src, size);
 }
 
 static inline void ctx_data_rd_check(ocf_ctx_t ctx, void *dst,
@@ -99,7 +100,7 @@ static inline void ctx_data_wr_check(ocf_ctx_t ctx, ctx_data_t *dst,
 static inline uint32_t ctx_data_zero(ocf_ctx_t ctx, ctx_data_t *dst,
 		uint32_t size)
 {
-	return ctx->ctx_ops->data.zero(dst, size);
+	return ctx->ops->data.zero(dst, size);
 }
 
 static inline void ctx_data_zero_check(ocf_ctx_t ctx, ctx_data_t *dst,
@@ -113,7 +114,7 @@ static inline void ctx_data_zero_check(ocf_ctx_t ctx, ctx_data_t *dst,
 static inline uint32_t ctx_data_seek(ocf_ctx_t ctx, ctx_data_t *dst,
 		ctx_data_seek_t seek, uint32_t size)
 {
-	return ctx->ctx_ops->data.seek(dst, seek, size);
+	return ctx->ops->data.seek(dst, seek, size);
 }
 
 static inline void ctx_data_seek_check(ocf_ctx_t ctx, ctx_data_t *dst,
@@ -127,59 +128,59 @@ static inline void ctx_data_seek_check(ocf_ctx_t ctx, ctx_data_t *dst,
 static inline uint64_t ctx_data_cpy(ocf_ctx_t ctx, ctx_data_t *dst, ctx_data_t *src,
 		uint64_t to, uint64_t from, uint64_t bytes)
 {
-	return ctx->ctx_ops->data.copy(dst, src, to, from, bytes);
+	return ctx->ops->data.copy(dst, src, to, from, bytes);
 }
 
 static inline void ctx_data_secure_erase(ocf_ctx_t ctx, ctx_data_t *dst)
 {
-	return ctx->ctx_ops->data.secure_erase(dst);
+	return ctx->ops->data.secure_erase(dst);
 }
 
 static inline int ctx_queue_init(ocf_ctx_t ctx, ocf_queue_t queue)
 {
-	return ctx->ctx_ops->queue.init(queue);
+	return ctx->ops->queue.init(queue);
 }
 
 static inline void ctx_queue_kick(ocf_ctx_t ctx, ocf_queue_t queue,
 		bool allow_sync)
 {
-	if (allow_sync && ctx->ctx_ops->queue.kick_sync)
-		ctx->ctx_ops->queue.kick_sync(queue);
+	if (allow_sync && ctx->ops->queue.kick_sync)
+		ctx->ops->queue.kick_sync(queue);
 	else
-		ctx->ctx_ops->queue.kick(queue);
+		ctx->ops->queue.kick(queue);
 }
 
 static inline void ctx_queue_stop(ocf_ctx_t ctx, ocf_queue_t queue)
 {
-	ctx->ctx_ops->queue.stop(queue);
+	ctx->ops->queue.stop(queue);
 }
 
 static inline int ctx_cleaner_init(ocf_ctx_t ctx, ocf_cleaner_t cleaner)
 {
-	return ctx->ctx_ops->cleaner.init(cleaner);
+	return ctx->ops->cleaner.init(cleaner);
 }
 
 static inline void ctx_cleaner_stop(ocf_ctx_t ctx, ocf_cleaner_t cleaner)
 {
-	ctx->ctx_ops->cleaner.stop(cleaner);
+	ctx->ops->cleaner.stop(cleaner);
 }
 
 static inline int ctx_metadata_updater_init(ocf_ctx_t ctx,
 		ocf_metadata_updater_t mu)
 {
-	return ctx->ctx_ops->metadata_updater.init(mu);
+	return ctx->ops->metadata_updater.init(mu);
 }
 
 static inline void ctx_metadata_updater_kick(ocf_ctx_t ctx,
 		ocf_metadata_updater_t mu)
 {
-	ctx->ctx_ops->metadata_updater.kick(mu);
+	ctx->ops->metadata_updater.kick(mu);
 }
 
 static inline void ctx_metadata_updater_stop(ocf_ctx_t ctx,
 		ocf_metadata_updater_t mu)
 {
-	ctx->ctx_ops->metadata_updater.stop(mu);
+	ctx->ops->metadata_updater.stop(mu);
 }
 
 /**

--- a/src/ocf_logger.c
+++ b/src/ocf_logger.c
@@ -47,6 +47,13 @@ int ocf_log_stack_trace_raw(ocf_logger_t logger)
 	return logger->ops->dump_stack(logger);
 }
 
+void ocf_logger_init(ocf_logger_t logger,
+		const struct ocf_logger_ops *ops, void *priv)
+{
+	logger->ops = ops;
+	logger->priv = priv;
+}
+
 int ocf_logger_open(ocf_logger_t logger)
 {
 	if (!logger->ops->open)

--- a/src/ocf_logger_priv.h
+++ b/src/ocf_logger_priv.h
@@ -21,6 +21,9 @@ int ocf_log_raw_rl(ocf_logger_t logger, const char *func_name);
 
 int ocf_log_stack_trace_raw(ocf_logger_t logger);
 
+void ocf_logger_init(ocf_logger_t logger,
+		const struct ocf_logger_ops *ops, void *priv);
+
 int ocf_logger_open(ocf_logger_t logger);
 
 void ocf_logger_close(ocf_logger_t logger);


### PR DESCRIPTION
This may be used in logger implementations that need file
name or descriptor to initialize properly.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/51)
<!-- Reviewable:end -->
