### PR TITLE
Improvement of metadata flush setting

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -117,7 +117,8 @@ void ocf_engine_update_req_info(struct ocf_cache *cache,
 			req->info.dirty_any++;
 
 			/* Check if cache line is fully dirty */
-			if (metadata_test_dirty_all(cache, _entry->coll_idx))
+			if (metadata_test_dirty_sec(cache, _entry->coll_idx, 
+				start_sector, end_sector))
 				req->info.dirty_all++;
 		}
 

--- a/src/utils/utils_cache_line.c
+++ b/src/utils/utils_cache_line.c
@@ -133,9 +133,9 @@ void set_cache_line_clean(struct ocf_cache *cache, uint8_t start_bit,
 			evict_policy_ops[evp_type].clean_cline(cache, part_id, line);
 
 		ocf_purge_cleaning_policy(cache, line);
+		ocf_metadata_flush_mark(cache, req, map_idx, CLEAN, start_bit, 
+					end_bit);
 	}
-
-	ocf_metadata_flush_mark(cache, req, map_idx, CLEAN, start_bit, end_bit);
 }
 
 void set_cache_line_dirty(struct ocf_cache *cache, uint8_t start_bit,
@@ -169,9 +169,10 @@ void set_cache_line_dirty(struct ocf_cache *cache, uint8_t start_bit,
 
 		if (likely(evict_policy_ops[evp_type].dirty_cline))
 			evict_policy_ops[evp_type].dirty_cline(cache, part_id, line);
+	
+		ocf_metadata_flush_mark(cache, req, map_idx, DIRTY, start_bit, 
+					end_bit);
 	}
 
 	ocf_cleaning_set_hot_cache_line(cache, line);
-
-	ocf_metadata_flush_mark(cache, req, map_idx, DIRTY, start_bit, end_bit);
 }


### PR DESCRIPTION
Update the code to match with those design points:
a) Only mark flush flag when some sector status are really changed;
    Function set_cache_line_dirty and set_cache_line_clean is updated for this.
b) When checking dirty_all, only check the sectors in the request instead of the whole cache line;
    Replace metadata_test_dirty_all with metadata_test_dirty_sec in ocf_engine_update_req_info.

More details about fixes.
If the new write IO will NOT introduce new dirty sector, there is NO need to flush the metadata; Because the existing metadata already have enough information to track the dirty data
If the new write IO will introduce new dirty sectors, then we need to flush the metadata to track the new dirty sectors on the cache drives.
Our current OCF code tries to match the design point, but there is a small hole.

We rely on "dirty_all" to check whether all the sectors of the request are dirty.

But now we check the dirty bits for all sectors of each mapped cache line.

For the first and last core line in the request, this may be wrong.

Because, the first and last core line in the request may be NOT complete. For example, the request may want to get only 8th sector of the first core line (block) and the 1st sector of the last core line (block).

So for the first and last core line, we should only check the dirty bits of corresponding sectors requested by the write IO.

Or we'll introduce unnecessary metadata flush and reduce the write performance.

So use metadata_test_dirty_sec to check each cache line.
And for the first and last core line, maybe partial cache line will be checked.
For other core lines, the whole cache line will be checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/55)
<!-- Reviewable:end -->
