### PR TITLE
Remove undefined declaration: ocf_cleaner_set_io_queue

### DIFF
--- a/inc/ocf_cleaner.h
+++ b/inc/ocf_cleaner.h
@@ -31,14 +31,6 @@ typedef void (*ocf_cleaner_end_t)(ocf_cleaner_t cleaner, uint32_t interval);
 void ocf_cleaner_set_cmpl(ocf_cleaner_t cleaner, ocf_cleaner_end_t fn);
 
 /**
- * @brief Set cleaner queue
- *
- * @param[in] cleaner Cleaner instance
- * @param[in] io_queue Queue handle
- */
-void ocf_cleaner_set_io_queue(ocf_cleaner_t cleaner, ocf_queue_t io_queue);
-
-/**
  * @brief Run cleaner
  *
  * @param[in] c Cleaner instance to run


### PR DESCRIPTION
Function ocf_cleaner_set_io_queue is not used and not defined
But is declared

This patch removes declaration

Signed-off-by: Vitaliy Mysak <vitaliy.mysak@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/78)
<!-- Reviewable:end -->
