### PR TITLE
Asynchronous flush and purge operations - part 1

### DIFF
--- a/src/utils/utils_cleaner.h
+++ b/src/utils/utils_cleaner.h
@@ -55,6 +55,8 @@ struct flush_data {
 	ocf_core_id_t core_id;
 };
 
+typedef void (*ocf_flush_containter_coplete_t)(void *ctx);
+
 /**
  * @brief Flush table container
  */
@@ -66,14 +68,15 @@ struct flush_container {
 
 	struct ocf_cleaner_attribs attribs;
 	ocf_cache_t cache;
-	env_atomic *progress;
-	env_atomic *error;
-	env_waitqueue *wq;
-	env_atomic completed;
+
+	struct ocf_request *req;
 
 	uint64_t flush_portion;
 	uint64_t ticks1;
 	uint64_t ticks2;
+
+	ocf_flush_containter_coplete_t end;
+	struct ocf_mngt_cache_flush_context *context;
 };
 
 /**


### PR DESCRIPTION
Flush and purge management entry points are reworked to be mostly asynchronous. What's left is flush_begin function, where flush_mutex and dirty request waitqueue are still synchronous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/80)
<!-- Reviewable:end -->
