### PR TITLE
Put cache after doing pipeline_destroy

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2068,10 +2068,7 @@ static void ocf_mngt_cache_stop_finish(ocf_pipeline_t pipeline,
 	cache->valid_ocf_cache_device_t = 0;
 	/* Remove cache from the list */
 	list_del(&cache->list);
-	/* Finally release cache instance */
-	ocf_mngt_cache_put(cache);
 	env_mutex_unlock(&ctx->lock);
-
 
 	if (context->error == -OCF_ERR_WRITE_CACHE) {
 		ocf_log(ctx, log_warn, "Stopped cache %s with errors\n",
@@ -2087,6 +2084,9 @@ static void ocf_mngt_cache_stop_finish(ocf_pipeline_t pipeline,
 	context->cmpl(cache, context->priv, context->error);
 
 	ocf_pipeline_destroy(context->pipeline);
+
+	/* Finally release cache instance */
+	ocf_mngt_cache_put(cache);
 }
 
 struct ocf_pipeline_properties ocf_mngt_cache_stop_pipeline_properties = {


### PR DESCRIPTION
Cache is used during pipeline_destroy which means that
  doing put_cache before destroying pipeline may result in
  accessing memory that was freed.

Signed-off-by: Vitaliy Mysak <vitaliy.mysak@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/86)
<!-- Reviewable:end -->
