### PR TITLE
Increase IO class name length limit

### DIFF
--- a/inc/ocf_def.h
+++ b/inc/ocf_def.h
@@ -293,7 +293,7 @@ typedef enum {
 #define OCF_IO_CLASS_INVALID OCF_IO_CLASS_MAX
 
 /** Maximum size of the IO class name */
-#define OCF_IO_CLASS_NAME_MAX 33
+#define OCF_IO_CLASS_NAME_MAX 1024
 
 /** IO class priority which indicates pinning */
 #define OCF_IO_CLASS_PRIO_PINNED -1


### PR DESCRIPTION
This is needed to implement flexible classifier in Linux kernel adapter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/89)
<!-- Reviewable:end -->
