### PR TITLE
Return error on start when detected old metadata of not flushed cache.

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -959,7 +959,7 @@ static void _ocf_mngt_attach_load_properties_end(void *priv, int error,
 	}
 
 	context->metadata.shutdown_status = properties->shutdown_status;
-	context->metadata.dirty_flushed = properties->shutdown_status;
+	context->metadata.dirty_flushed = properties->dirty_flushed;
 
 	if (cache->device->init_mode == ocf_init_mode_load) {
 		context->metadata.line_size = properties->line_size;


### PR DESCRIPTION
Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/92)
<!-- Reviewable:end -->
