### PR TITLE
Add volume_params argument to bottom volume open

### DIFF
--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -341,6 +341,12 @@ struct ocf_mngt_cache_device_config {
 	 * @brief If set, cache device will be discarded on cache start
 	 */
 	bool discard_on_start;
+
+	/**
+	 * @brief Optional opaque volume parameters, passed down to cache volume
+	 * open callback
+	 */
+	void *volume_params;
 };
 
 /**

--- a/inc/ocf_volume.h
+++ b/inc/ocf_volume.h
@@ -88,8 +88,9 @@ struct ocf_volume_ops {
 	 *	 be called before any other operation on volume
 	 *
 	 * @param[in] volume Volume
+	 * @param[in] volume_params optional volume parameters, opaque to OCF
 	 */
-	int (*open)(ocf_volume_t volume);
+	int (*open)(ocf_volume_t volume, void *volume_params);
 
 	/**
 	 * @brief Close volume
@@ -285,10 +286,11 @@ void ocf_volume_submit_discard(struct ocf_io *io);
  * @brief Open volume
  *
  * @param[in] volume Volume
+ * @param[in] volume_params Opaque volume params
  *
  * @return Zero when success, othewise en error
  */
-int ocf_volume_open(ocf_volume_t volume);
+int ocf_volume_open(ocf_volume_t volume, void *volume_params);
 
 /**
  * @brief Get volume max io size

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -412,7 +412,7 @@ static int _ocf_mngt_init_instance_add_cores(
 			ocf_cache_log(cache, log_info,
 					"Attached core %u from pool\n", i);
 		} else {
-			ret = ocf_volume_open(&core->volume);
+			ret = ocf_volume_open(&core->volume, NULL);
 			if (ret == -OCF_ERR_NOT_OPEN_EXC) {
 				ocf_cache_log(cache, log_warn,
 						"Cannot open core %u. "
@@ -616,7 +616,8 @@ static void _ocf_mngt_attach_cache_device(ocf_pipeline_t pipeline,
 	 * Open cache device, It has to be done first because metadata service
 	 * need to know size of cache device.
 	 */
-	ret = ocf_volume_open(&cache->device->volume);
+	ret = ocf_volume_open(&cache->device->volume,
+			context->cfg.volume_params);
 	if (ret) {
 		ocf_cache_log(cache, log_err, "ERROR: Cache not available\n");
 		goto err;
@@ -1123,7 +1124,7 @@ int ocf_mngt_get_ram_needed(ocf_cache_t cache,
 	if (result)
 		return result;
 
-	result = ocf_volume_open(&volume);
+	result = ocf_volume_open(&volume, cfg->volume_params);
 	if (result) {
 		ocf_volume_deinit(&volume);
 		return result;

--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -38,7 +38,7 @@ static int _ocf_mngt_cache_try_add_core(ocf_cache_t cache, ocf_core_t *core,
 		goto error_out;
 	}
 
-	result = ocf_volume_open(volume);
+	result = ocf_volume_open(volume, NULL);
 	if (result)
 		goto error_out;
 
@@ -187,7 +187,7 @@ static void _ocf_mngt_cache_add_core(ocf_cache_t cache,
 		}
 	}
 
-	result = ocf_volume_open(volume);
+	result = ocf_volume_open(volume, NULL);
 	if (result) {
 		ocf_pipeline_finish(context->pipeline, result);
 		return;
@@ -417,7 +417,7 @@ int ocf_mngt_core_init_front_volume(ocf_core_t core)
 	if (ret)
 		return ret;
 
-	return ocf_volume_open(&core->front_volume);
+	return ocf_volume_open(&core->front_volume, NULL);
 }
 
 static void ocf_mngt_cache_add_core_prepare(ocf_pipeline_t pipeline,

--- a/src/mngt/ocf_mngt_core_pool.c
+++ b/src/mngt/ocf_mngt_core_pool.c
@@ -38,7 +38,7 @@ int ocf_mngt_core_pool_add(ocf_ctx_t ctx, ocf_uuid_t uuid, uint8_t type)
 	if (result)
 		return result;
 
-	result = ocf_volume_open(volume);
+	result = ocf_volume_open(volume, NULL);
 	if (result) {
 		ocf_volume_deinit(volume);
 		return result;

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -475,7 +475,7 @@ static void ocf_core_volume_submit_discard(struct ocf_io *io)
 
 /* *** VOLUME OPS *** */
 
-static int ocf_core_volume_open(ocf_volume_t volume)
+static int ocf_core_volume_open(ocf_volume_t volume, void *volume_params)
 {
 	struct ocf_core_volume *core_volume = ocf_volume_get_priv(volume);
 	const struct ocf_volume_uuid *uuid = ocf_volume_get_uuid(volume);

--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -264,14 +264,14 @@ void ocf_volume_submit_discard(struct ocf_io *io)
 	io->volume->type->properties->ops.submit_discard(io);
 }
 
-int ocf_volume_open(ocf_volume_t volume)
+int ocf_volume_open(ocf_volume_t volume, void *volume_params)
 {
 	int ret;
 
 	ENV_BUG_ON(!volume->type->properties->ops.open);
 	ENV_BUG_ON(volume->opened);
 
-	ret = volume->type->properties->ops.open(volume);
+	ret = volume->type->properties->ops.open(volume, volume_params);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This pointer is used to provide optional volume specific data
from the user down to bottom volume open callback. volume_params
is provided to OCF in ocf_mngt_cache_device_config.volume_params.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/94)
<!-- Reviewable:end -->
