### PR TITLE
Make pyocf work with async API

### DIFF
--- a/tests/functional/pyocf/ocf.py
+++ b/tests/functional/pyocf/ocf.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
-from ctypes import *
+from ctypes import c_void_p, cdll
 
 lib = None
 

--- a/tests/functional/pyocf/types/cleaner.py
+++ b/tests/functional/pyocf/types/cleaner.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_void_p, CFUNCTYPE, Structure, c_int
 from .shared import SharedOcfObject
 
 

--- a/tests/functional/pyocf/types/ctx.py
+++ b/tests/functional/pyocf/types/ctx.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_void_p, Structure, c_char_p, cast, pointer, byref
 from enum import IntEnum
 
 from .logger import LoggerOps, Logger

--- a/tests/functional/pyocf/types/data.py
+++ b/tests/functional/pyocf/types/data.py
@@ -3,7 +3,20 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import (
+    c_void_p,
+    c_uint32,
+    CFUNCTYPE,
+    c_uint64,
+    create_string_buffer,
+    cast,
+    memset,
+    c_char_p,
+    string_at,
+    Structure,
+    c_int,
+    memmove,
+)
 from enum import IntEnum
 from hashlib import md5
 
@@ -150,7 +163,9 @@ class Data(SharedOcfObject):
     @staticmethod
     @DataOps.COPY
     def _copy(dst, src, end, start, size):
-        return Data.get_instance(dst).copy(Data.get_instance(src), end, start, size)
+        return Data.get_instance(dst).copy(
+            Data.get_instance(src), end, start, size
+        )
 
     @staticmethod
     @DataOps.SECURE_ERASE

--- a/tests/functional/pyocf/types/io.py
+++ b/tests/functional/pyocf/types/io.py
@@ -3,8 +3,18 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
-from enum import IntEnum, IntFlag, auto
+from ctypes import (
+    c_void_p,
+    c_int,
+    c_uint32,
+    c_uint64,
+    CFUNCTYPE,
+    Structure,
+    POINTER,
+    byref,
+    cast,
+)
+from enum import IntEnum, auto
 
 from ..ocf import OcfLib
 from .data import Data
@@ -46,7 +56,9 @@ class Io(Structure):
     def from_pointer(cls, ref):
         c = cls.from_address(ref)
         cls._instances_[ref] = c
-        OcfLib.getInstance().ocf_io_set_cmpl_wrapper(byref(c), None, None, c.c_end)
+        OcfLib.getInstance().ocf_io_set_cmpl_wrapper(
+            byref(c), None, None, c.c_end
+        )
         return c
 
     @classmethod
@@ -78,8 +90,10 @@ class Io(Structure):
         Io.get_instance(io).handle(opaque)
 
     def end(self, err):
-        if err:
-            print("IO err {}".format(err))
+        try:
+            self.callback(err)
+        except:
+            pass
 
         self.put()
         self.del_object()

--- a/tests/functional/pyocf/types/logger.py
+++ b/tests/functional/pyocf/types/logger.py
@@ -3,7 +3,17 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import (
+    c_void_p,
+    Structure,
+    c_void_p,
+    c_char_p,
+    c_uint,
+    c_int,
+    cast,
+    CFUNCTYPE,
+    pointer,
+)
 from enum import IntEnum
 import logging
 from io import StringIO
@@ -113,7 +123,9 @@ class DefaultLogger(Logger):
         self.level = level
 
         ch = logging.StreamHandler()
-        fmt = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        fmt = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
         ch.setFormatter(fmt)
         ch.setLevel(LevelMapping[level])
         logger.addHandler(ch)
@@ -128,7 +140,9 @@ class DefaultLogger(Logger):
 class FileLogger(Logger):
     def __init__(self, f, console_level=None):
         super().__init__()
-        fmt = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        fmt = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
 
         fh = logging.FileHandler(f)
         fh.setLevel(logging.DEBUG)

--- a/tests/functional/pyocf/types/metadata_updater.py
+++ b/tests/functional/pyocf/types/metadata_updater.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_void_p, c_int, Structure, CFUNCTYPE
 from .shared import SharedOcfObject
 
 

--- a/tests/functional/pyocf/types/queue.py
+++ b/tests/functional/pyocf/types/queue.py
@@ -3,37 +3,70 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_void_p, CFUNCTYPE, Structure, byref
+from threading import Thread, Condition, Lock
 
 from ..ocf import OcfLib
-from .shared import SharedOcfObject, OcfError
+from .shared import OcfError
 
 
 class QueueOps(Structure):
     KICK = CFUNCTYPE(None, c_void_p)
     KICK_SYNC = CFUNCTYPE(None, c_void_p)
+    KICK = CFUNCTYPE(None, c_void_p)
     STOP = CFUNCTYPE(None, c_void_p)
 
-    _fields_ = [
-        ("kick", KICK),
-        ("kick_sync", KICK_SYNC),
-        ("stop", STOP),
-    ]
+    _fields_ = [("kick", KICK), ("kick_sync", KICK_SYNC), ("stop", STOP)]
+
+
+class Queue:
+    pass
 
 
 class Queue:
     _instances_ = {}
 
-    def __init__(self, cache):
-        self.ops = QueueOps(kick_sync=type(self)._kick_sync, stop=type(self)._stop)
-        self.handle = c_void_p()
+    @staticmethod
+    def io_queue_run(*, queue: Queue, kick: Condition):
+        def wait_predicate():
+            return queue.stop or OcfLib.getInstance().ocf_queue_pending_io(queue)
 
-        status = OcfLib.getInstance().ocf_queue_create(cache.cache_handle, byref(self.handle), byref(self.ops))
+        while True:
+            with kick:
+                kick.wait_for(wait_predicate)
+
+            queue.owner.lib.ocf_queue_run(queue)
+
+            if queue.stop and not queue.owner.lib.ocf_queue_pending_io(queue):
+                break
+
+    def __init__(self, cache, name, mngt_queue: bool = False):
+        self.owner = cache.owner
+
+        self.ops = QueueOps(kick=type(self)._kick, stop=type(self)._stop)
+
+        self.handle = c_void_p()
+        status = self.owner.lib.ocf_queue_create(
+            cache.cache_handle, byref(self.handle), byref(self.ops)
+        )
         if status:
             raise OcfError("Couldn't create queue object", status)
 
         Queue._instances_[self.handle.value] = self
-        cache.queues += [self]
+        self._as_parameter_ = self.handle
+
+        self.stop_lock = Lock()
+        self.stop = False
+        self.kick_condition = Condition(self.stop_lock)
+        self.thread = Thread(
+            group=None,
+            target=Queue.io_queue_run,
+            name=name,
+            kwargs={"queue": self, "kick": self.kick_condition},
+            daemon=True,
+        )
+        self.thread.start()
+        self.mngt_queue = mngt_queue
 
     @classmethod
     def get_instance(cls, ref):
@@ -45,12 +78,27 @@ class Queue:
         Queue.get_instance(ref).kick_sync()
 
     @staticmethod
+    @QueueOps.KICK
+    def _kick(ref):
+        Queue.get_instance(ref).kick()
+
+    @staticmethod
     @QueueOps.STOP
     def _stop(ref):
         Queue.get_instance(ref).stop()
 
     def kick_sync(self):
-        OcfLib.getInstance().ocf_queue_run(self.handle)
+        self.owner.lib.ocf_queue_run(self.handle)
+
+    def kick(self):
+        with self.kick_condition:
+            self.kick_condition.notify_all()
 
     def stop(self):
-        pass
+        with self.kick_condition:
+            self.stop = True
+            self.kick_condition.notify_all()
+
+        self.thread.join()
+        if self.mngt_queue:
+            self.owner.lib.ocf_queue_put(self)

--- a/tests/functional/pyocf/types/stats/cache.py
+++ b/tests/functional/pyocf/types/stats/cache.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_uint8, c_uint32, c_uint64, c_bool, c_int, Structure
 
 
 class _Inactive(Structure):

--- a/tests/functional/pyocf/types/stats/core.py
+++ b/tests/functional/pyocf/types/stats/core.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_uint32, c_uint64, Structure
 
-from .shared import *
+from .shared import OcfStatsReq, OcfStatsBlock, OcfStatsDebug, OcfStatsError
 
 
 class CoreStats(Structure):

--- a/tests/functional/pyocf/types/stats/shared.py
+++ b/tests/functional/pyocf/types/stats/shared.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from ctypes import *
+from ctypes import c_uint64, c_uint32, Structure
 
 
 class _Stat(Structure):

--- a/tests/functional/pyocf/utils.py
+++ b/tests/functional/pyocf/utils.py
@@ -2,7 +2,8 @@
 # Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
-from ctypes import *
+
+from ctypes import string_at
 
 
 def print_buffer(buf, length, offset=0, width=16, stop_after_zeros=0):
@@ -32,11 +33,11 @@ def print_buffer(buf, length, offset=0, width=16, stop_after_zeros=0):
             print("<{} zero bytes omitted>".format(zero_lines * width))
             zero_lines = 0
 
-        for x in cur_line:
-            x = int(x)
-            byteline += "{:02X} ".format(x)
-            if 31 < x < 126:
-                char = chr(x)
+        for byte in cur_line:
+            byte = int(byte)
+            byteline += "{:02X} ".format(byte)
+            if 31 < byte < 126:
+                char = chr(byte)
             else:
                 char = "."
             asciiline += char

--- a/tests/functional/tests/conftest.py
+++ b/tests/functional/tests/conftest.py
@@ -27,7 +27,7 @@ def pyocf_ctx():
 
     yield c
     for cache in c.caches:
-        cache.stop()
+        cache.stop(flush=False)
     c.exit()
 
 
@@ -39,4 +39,4 @@ def pyocf_ctx_log_buffer():
     c.register_volume_type(ErrorDevice)
     yield logger
     for cache in c.caches:
-        cache.stop()
+        cache.stop(flush=False)


### PR DESCRIPTION
Implemented OcfCompletion class to mimic completion, which in turn was used to serialize most of the calls to management API. Modified the Queue class to be handled in separate thread.
What's left:

- Split up pyocf into lower-level API wrappers and higher-level abstractions to enable tests which won't use the default implementations
- Document all the classes
- Enable WB
- Fix loading
- Make volumes on binary files to enable some unexpected reboot scenarios etc

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/95)
<!-- Reviewable:end -->
