### PR TITLE
Added original uuid deinitialization without freeing

### DIFF
--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -143,6 +143,7 @@ void ocf_volume_move(ocf_volume_t volume, ocf_volume_t from)
 	 */
 	from->opened = false;
 	from->priv = NULL;
+	from->uuid.data = NULL;
 }
 
 int ocf_volume_create(ocf_volume_t *volume, ocf_volume_type_t type,


### PR DESCRIPTION
There is a risk that without uuid.data pointer denitialization it will
be freed during original volume deinit, zeroing uuid.data pointer
prevents that.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/96)
<!-- Reviewable:end -->
