### PR TITLE
Make libocf.so loading CWD independent

### DIFF
--- a/tests/functional/pyocf/ocf.py
+++ b/tests/functional/pyocf/ocf.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 from ctypes import c_void_p, cdll
+import inspect
+import os
 
 lib = None
 
@@ -13,7 +15,12 @@ class OcfLib:
     @classmethod
     def getInstance(cls):
         if cls.__lib__ is None:
-            lib = cdll.LoadLibrary("./pyocf/libocf.so")
+            lib = cdll.LoadLibrary(
+                os.path.join(
+                    os.path.dirname(inspect.getfile(inspect.currentframe())),
+                    "libocf.so",
+                )
+            )
             lib.ocf_volume_get_uuid.restype = c_void_p
             lib.ocf_volume_get_uuid.argtypes = [c_void_p]
 


### PR DESCRIPTION
Previously you had to run pytest from tests/functional directory, otherwise it would fail to load the libocf.so. Now libocf.so is loaded from path relative to ocf.py. It's strangely hacky, but apparently it's the only sane way of doing it.

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/97)
<!-- Reviewable:end -->
