### PR TITLE
Fix core_new_io

### DIFF
--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -166,3 +166,5 @@ lib = OcfLib.getInstance()
 lib.ocf_core_get_volume.restype = c_void_p
 lib.ocf_volume_new_io.argtypes = [c_void_p]
 lib.ocf_volume_new_io.restype = c_void_p
+lib.ocf_core_get_volume.argtypes = [c_void_p]
+lib.ocf_core_get_volume.restype = c_void_p


### PR DESCRIPTION
Due to some pointer casting errors the core_new_io function would segfault. Now it's fixed

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/98)
<!-- Reviewable:end -->
