### PR TITLE
Reset interrupted flag in core_flush

### DIFF
--- a/src/mngt/ocf_mngt_flush.c
+++ b/src/mngt/ocf_mngt_flush.c
@@ -737,6 +737,7 @@ static void _ocf_mngt_core_flush(ocf_pipeline_t pipeline, void *priv,
 	else if (context->op == purge_core)
 		ocf_cache_log(cache, log_info, "Purging core\n");
 
+	context->cache->flushing_interrupted = 0;
 	_ocf_mngt_flush_core(context, _ocf_mngt_flush_core_complete);
 }
 


### PR DESCRIPTION
This line got lost in async flush rework

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/102)
<!-- Reviewable:end -->
