### PR TITLE
Fix flushing of volatile metadata containers

### DIFF
--- a/src/metadata/metadata_raw_volatile.c
+++ b/src/metadata/metadata_raw_volatile.c
@@ -42,7 +42,7 @@ void raw_volatile_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
 void raw_volatile_flush_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
 		ocf_metadata_end_t cmpl, void *priv)
 {
-	cmpl(priv, -ENOTSUP);
+	cmpl(priv, 0);
 }
 
 /*


### PR DESCRIPTION
Before async metadata we used to return 0 on flushing volatile
containers, this way we didn't have to special-case them.
This change brings back this behavior.

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/105)
<!-- Reviewable:end -->
