### PR TITLE
Fix leaky tests

### DIFF
--- a/tests/functional/pyocf/types/data.py
+++ b/tests/functional/pyocf/types/data.py
@@ -63,7 +63,7 @@ class Data(SharedOcfObject):
     _fields_ = [("data", c_void_p)]
 
     def __init__(self, byte_count: int):
-        self.size = byte_count
+        self.size = int(byte_count)
         self.position = 0
         self.buffer = create_string_buffer(int(self.size))
         self.data = cast(self.buffer, c_void_p)
@@ -204,7 +204,10 @@ class Data(SharedOcfObject):
         return to_move
 
     def copy(self, src, end, start, size):
-        return size
+        to_write = min(self.size, size, src.size)
+
+        memmove(self.data, src.data, to_write)
+        return to_write
 
     def secure_erase(self):
         pass

--- a/tests/functional/pyocf/types/shared.py
+++ b/tests/functional/pyocf/types/shared.py
@@ -98,7 +98,7 @@ class SharedOcfObject(Structure):
         try:
             return cls._instances_[ref]
         except:
-            logging.get_logger("pyocf").error(
+            logging.getLogger("pyocf").error(
                 "OcfSharedObject corruption. wanted: {} instances: {}".format(
                     ref, cls._instances_
                 )

--- a/tests/functional/pyocf/utils.py
+++ b/tests/functional/pyocf/utils.py
@@ -42,7 +42,7 @@ def print_buffer(buf, length, offset=0, width=16, stop_after_zeros=0):
                 char = "."
             asciiline += char
 
-        print("{:#08X}\t{}\t{}".format(addr, byteline, asciiline))
+        print("0x{:08X}\t{}\t{}".format(addr, byteline, asciiline))
         whole_buffer_empty = False
 
     if whole_buffer_empty:

--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -20,9 +20,9 @@ def test_ctx_fixture(pyocf_ctx):
 
 
 def test_adding_cores(pyocf_ctx):
-    cache_device = Volume(S.from_MiB(200))
-    core1_device = Volume(S.from_MiB(400))
-    core2_device = Volume(S.from_MiB(400))
+    cache_device = Volume(S.from_MiB(100))
+    core1_device = Volume(S.from_MiB(10))
+    core2_device = Volume(S.from_MiB(10))
 
     cache = Cache.start_on_device(cache_device)
     core1 = Core.using_device(core1_device)
@@ -33,8 +33,8 @@ def test_adding_cores(pyocf_ctx):
 
 
 def test_adding_core_twice(pyocf_ctx):
-    cache_device = Volume(S.from_MiB(200))
-    core_device = Volume(S.from_MiB(400))
+    cache_device = Volume(S.from_MiB(100))
+    core_device = Volume(S.from_MiB(10))
 
     cache = Cache.start_on_device(cache_device)
     core = Core.using_device(core_device)
@@ -46,7 +46,7 @@ def test_adding_core_twice(pyocf_ctx):
 
 def test_simple_wt_write(pyocf_ctx):
     cache_device = Volume(S.from_MiB(100))
-    core_device = Volume(S.from_MiB(200))
+    core_device = Volume(S.from_MiB(10))
 
     cache = Cache.start_on_device(cache_device)
     core = Core.using_device(core_device)

--- a/tests/functional/tests/conftest.py
+++ b/tests/functional/tests/conftest.py
@@ -5,12 +5,12 @@
 
 import os
 import sys
-
 import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 from pyocf.types.logger import LogLevel, DefaultLogger, BufferLogger
 from pyocf.types.volume import Volume, ErrorDevice
+from pyocf.types.io import Io
 from pyocf.types.ctx import get_default_ctx
 from pyocf.ocf import OcfLib
 
@@ -24,7 +24,6 @@ def pyocf_ctx():
     c = get_default_ctx(DefaultLogger(LogLevel.WARN))
     c.register_volume_type(Volume)
     c.register_volume_type(ErrorDevice)
-
     yield c
     for cache in c.caches:
         cache.stop(flush=False)


### PR DESCRIPTION
Change instance tracking dictionary in Volume to weakrefs to prevent it
from holding on to Volumes which should be disposed of and leaking
buffers behind them. Also, implement proper copy for Data objects.

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/108)
<!-- Reviewable:end -->
