### PR TITLE
Fix leaky tests

### DIFF
--- a/inc/ocf_def.h
+++ b/inc/ocf_def.h
@@ -31,7 +31,7 @@
 /**
  * Minimum cache size in bytes
  */
-#define OCF_CACHE_SIZE_MIN	(100 * MiB)
+#define OCF_CACHE_SIZE_MIN	(20 * MiB)
 /**
  * Size of cache name
  */

--- a/tests/functional/pyocf/types/io.py
+++ b/tests/functional/pyocf/types/io.py
@@ -14,7 +14,7 @@ from ctypes import (
     byref,
     cast,
 )
-from enum import IntEnum, auto
+from enum import IntEnum
 
 from ..ocf import OcfLib
 from .data import Data
@@ -113,7 +113,6 @@ class Io(Structure):
         OcfLib.getInstance().ocf_io_set_data_wrapper(byref(self), data, 0)
 
     def set_queue(self, queue: Queue):
-        self.queue = queue
         OcfLib.getInstance().ocf_io_set_queue_wrapper(byref(self), queue.handle)
 
 

--- a/tests/functional/pyocf/types/logger.py
+++ b/tests/functional/pyocf/types/logger.py
@@ -6,7 +6,6 @@
 from ctypes import (
     c_void_p,
     Structure,
-    c_void_p,
     c_char_p,
     c_uint,
     c_int,
@@ -17,6 +16,7 @@ from ctypes import (
 from enum import IntEnum
 import logging
 from io import StringIO
+import weakref
 
 from ..ocf import OcfLib
 
@@ -81,7 +81,7 @@ class Logger(Structure):
         )
         self.priv = LoggerPriv(_log=self._log)
         self._as_parameter_ = cast(pointer(self.priv), c_void_p).value
-        self._instances_[self._as_parameter_] = self
+        self._instances_[self._as_parameter_] = weakref.ref(self)
 
     def get_ops(self):
         return self.ops
@@ -92,7 +92,7 @@ class Logger(Structure):
     @classmethod
     def get_instance(cls, ctx: int):
         priv = OcfLib.getInstance().ocf_logger_get_priv(ctx)
-        return cls._instances_[priv]
+        return cls._instances_[priv]()
 
     @staticmethod
     @LoggerOps.LOG

--- a/tests/functional/pyocf/types/shared.py
+++ b/tests/functional/pyocf/types/shared.py
@@ -98,7 +98,7 @@ class SharedOcfObject(Structure):
         try:
             return cls._instances_[ref]
         except:
-            logging.get_logger("pyocf").error(
+            logging.getLogger("pyocf").error(
                 "OcfSharedObject corruption. wanted: {} instances: {}".format(
                     ref, cls._instances_
                 )
@@ -130,8 +130,3 @@ class CacheLines(S):
 
     def __int__(self):
         return int(self.bytes / self.line_size)
-
-    def __str__(self):
-        return "{} ({})".format(int(self), super().__str__())
-
-    __repr__ = __str__

--- a/tests/functional/pyocf/utils.py
+++ b/tests/functional/pyocf/utils.py
@@ -42,7 +42,7 @@ def print_buffer(buf, length, offset=0, width=16, stop_after_zeros=0):
                 char = "."
             asciiline += char
 
-        print("{:#08X}\t{}\t{}".format(addr, byteline, asciiline))
+        print("0x{:08X}\t{}\t{}".format(addr, byteline, asciiline))
         whole_buffer_empty = False
 
     if whole_buffer_empty:

--- a/tests/functional/pytest.ini
+++ b/tests/functional/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-log_cli = 1
-log_cli_level = INFO
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -20,8 +20,8 @@ def test_ctx_fixture(pyocf_ctx):
 
 
 def test_simple_wt_write(pyocf_ctx):
-    cache_device = Volume(S.from_MiB(100))
-    core_device = Volume(S.from_MiB(200))
+    cache_device = Volume(S.from_MiB(30))
+    core_device = Volume(S.from_MiB(30))
 
     cache = Cache.start_on_device(cache_device)
     core = Core.using_device(core_device)
@@ -49,17 +49,18 @@ def test_simple_wt_write(pyocf_ctx):
     assert stats["usage"]["occupancy"]["value"] == 1
 
     assert core.exp_obj_md5() == core_device.md5()
+    cache.stop()
 
 
 def test_start_corrupted_metadata_lba(pyocf_ctx):
-    cache_device = ErrorDevice(S.from_MiB(100), error_sectors=set([0]))
+    cache_device = ErrorDevice(S.from_MiB(30), error_sectors=set([0]))
 
     with pytest.raises(OcfError, match="OCF_ERR_WRITE_CACHE"):
         cache = Cache.start_on_device(cache_device)
 
 
 def test_load_cache_no_preexisting_data(pyocf_ctx):
-    cache_device = Volume(S.from_MiB(100))
+    cache_device = Volume(S.from_MiB(30))
 
     with pytest.raises(OcfError, match="OCF_ERR_START_CACHE_FAIL"):
         cache = Cache.load_from_device(cache_device)
@@ -68,7 +69,7 @@ def test_load_cache_no_preexisting_data(pyocf_ctx):
 # TODO: Find out why this fails and fix
 @pytest.mark.xfail
 def test_load_cache(pyocf_ctx):
-    cache_device = Volume(S.from_MiB(100))
+    cache_device = Volume(S.from_MiB(30))
 
     cache = Cache.start_on_device(cache_device)
     cache.stop()

--- a/tests/functional/tests/conftest.py
+++ b/tests/functional/tests/conftest.py
@@ -5,14 +5,12 @@
 
 import os
 import sys
-
 import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 from pyocf.types.logger import LogLevel, DefaultLogger, BufferLogger
 from pyocf.types.volume import Volume, ErrorDevice
 from pyocf.types.ctx import get_default_ctx
-from pyocf.ocf import OcfLib
 
 
 def pytest_configure(config):
@@ -24,10 +22,9 @@ def pyocf_ctx():
     c = get_default_ctx(DefaultLogger(LogLevel.WARN))
     c.register_volume_type(Volume)
     c.register_volume_type(ErrorDevice)
-
     yield c
-    for cache in c.caches:
-        cache.stop(flush=False)
+    for cache in c.caches[:]:
+        cache.stop()
     c.exit()
 
 
@@ -39,4 +36,4 @@ def pyocf_ctx_log_buffer():
     c.register_volume_type(ErrorDevice)
     yield logger
     for cache in c.caches:
-        cache.stop(flush=False)
+        cache.stop()

--- a/tests/functional/tests/management/test_add_remove.py
+++ b/tests/functional/tests/management/test_add_remove.py
@@ -19,8 +19,10 @@ from pyocf.types.shared import OcfError, OcfCompletion, CacheLineSize
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_adding_core(pyocf_ctx, cache_mode, cls):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
-    cache = Cache.start_on_device(cache_device, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device = Volume(S.from_MiB(30))
+    cache = Cache.start_on_device(
+        cache_device, cache_mode=cache_mode, cache_line_size=cls
+    )
 
     # Create core device
     core_device = Volume(S.from_MiB(10))
@@ -42,8 +44,10 @@ def test_adding_core(pyocf_ctx, cache_mode, cls):
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_removing_core(pyocf_ctx, cache_mode, cls):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
-    cache = Cache.start_on_device(cache_device, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device = Volume(S.from_MiB(30))
+    cache = Cache.start_on_device(
+        cache_device, cache_mode=cache_mode, cache_line_size=cls
+    )
 
     # Create core device
     core_device = Volume(S.from_MiB(10))
@@ -60,9 +64,9 @@ def test_removing_core(pyocf_ctx, cache_mode, cls):
     assert stats["conf"]["core_count"] == 0
 
 
-def test_100add_remove(pyocf_ctx):
+def test_30add_remove(pyocf_ctx):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
+    cache_device = Volume(S.from_MiB(30))
     cache = Cache.start_on_device(cache_device)
 
     # Create core device
@@ -71,7 +75,7 @@ def test_100add_remove(pyocf_ctx):
 
     # Add and remove core device in a loop 100 times
     # Check statistics after every operation
-    for i in range(0, 100):
+    for i in range(0, 30):
         cache.add_core(core)
         stats = cache.get_stats()
         assert stats["conf"]["core_count"] == 1
@@ -83,7 +87,7 @@ def test_100add_remove(pyocf_ctx):
 
 def test_10add_remove_with_io(pyocf_ctx):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
+    cache_device = Volume(S.from_MiB(30))
     cache = Cache.start_on_device(cache_device)
 
     # Create core device
@@ -112,12 +116,12 @@ def test_10add_remove_with_io(pyocf_ctx):
         assert stats["conf"]["core_count"] == 0
 
 
-def test_add_remove_50core(pyocf_ctx):
+def test_add_remove_30core(pyocf_ctx):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
+    cache_device = Volume(S.from_MiB(30))
     cache = Cache.start_on_device(cache_device)
     core_devices = []
-    core_amount = 50
+    core_amount = 30
 
     # Add 50 cores and check stats after each addition
     for i in range(0, core_amount):
@@ -143,11 +147,11 @@ def test_adding_to_random_cache(pyocf_ctx):
     cache_devices = []
     core_devices = {}
     cache_amount = 5
-    core_amount = 50
+    core_amount = 30
 
     # Create 5 cache devices
     for i in range(0, cache_amount):
-        cache_device = Volume(S.from_MiB(100))
+        cache_device = Volume(S.from_MiB(30))
         cache = Cache.start_on_device(cache_device)
         cache_devices.append(cache)
 
@@ -173,8 +177,10 @@ def test_adding_to_random_cache(pyocf_ctx):
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_adding_core_twice(pyocf_ctx, cache_mode, cls):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
-    cache = Cache.start_on_device(cache_device, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device = Volume(S.from_MiB(30))
+    cache = Cache.start_on_device(
+        cache_device, cache_mode=cache_mode, cache_line_size=cls
+    )
 
     # Create core device
     core_device = Volume(S.from_MiB(10))
@@ -196,12 +202,16 @@ def test_adding_core_twice(pyocf_ctx, cache_mode, cls):
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_adding_core_already_used(pyocf_ctx, cache_mode, cls):
     # Start first cache device
-    cache_device1 = Volume(S.from_MiB(100))
-    cache1 = Cache.start_on_device(cache_device1, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device1 = Volume(S.from_MiB(30))
+    cache1 = Cache.start_on_device(
+        cache_device1, cache_mode=cache_mode, cache_line_size=cls
+    )
 
     # Start second cache device
-    cache_device2 = Volume(S.from_MiB(100))
-    cache2 = Cache.start_on_device(cache_device2, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device2 = Volume(S.from_MiB(30))
+    cache2 = Cache.start_on_device(
+        cache_device2, cache_mode=cache_mode, cache_line_size=cls
+    )
 
     # Create core device
     core_device = Volume(S.from_MiB(10))
@@ -226,8 +236,10 @@ def test_adding_core_already_used(pyocf_ctx, cache_mode, cls):
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_add_remove_incrementally(pyocf_ctx, cache_mode, cls):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
-    cache = Cache.start_on_device(cache_device, cache_mode=cache_mode, cache_line_size=cls)
+    cache_device = Volume(S.from_MiB(30))
+    cache = Cache.start_on_device(
+        cache_device, cache_mode=cache_mode, cache_line_size=cls
+    )
     core_devices = []
     core_amount = 5
 

--- a/tests/functional/tests/management/test_change_mode.py
+++ b/tests/functional/tests/management/test_change_mode.py
@@ -16,8 +16,10 @@ from pyocf.types.shared import CacheLineSize
 @pytest.mark.parametrize("cls", CacheLineSize)
 def test_change_cache_mode(pyocf_ctx, from_cm, to_cm, cls):
     # Start cache device
-    cache_device = Volume(S.from_MiB(100))
-    cache = Cache.start_on_device(cache_device, cache_mode=from_cm, cache_line_size=cls)
+    cache_device = Volume(S.from_MiB(30))
+    cache = Cache.start_on_device(
+        cache_device, cache_mode=from_cm, cache_line_size=cls
+    )
 
     # Check if started with correct cache mode
     stats = cache.get_stats()


### PR DESCRIPTION
Fix leaky tests

Fix some instance tracking to prevent Python-side objects from leaking
buffers.
Also, reduce min size of Cache instance (real minimum should be around ~~19MiB,
but we need to make it more deterministic and 20 MiB seems to be reasonable).

Still some stuff left to do, but it needs more investigation and, for
now, this should suffice just to enable some form of CI.

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/115)
<!-- Reviewable:end -->
