### PR TITLE
Wait for IO put in volume close

### DIFF
--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -79,6 +79,9 @@ int ocf_volume_init(ocf_volume_t volume, ocf_volume_type_t type,
 	if (!volume->priv)
 		return -OCF_ERR_NO_MEM;
 
+	ocf_refcnt_init(&volume->refcnt);
+	ocf_refcnt_freeze(&volume->refcnt);
+
 	if (!uuid) {
 		volume->uuid.size = 0;
 		volume->uuid.data = NULL;
@@ -109,6 +112,7 @@ int ocf_volume_init(ocf_volume_t volume, ocf_volume_type_t type,
 	return 0;
 
 err:
+	ocf_refcnt_unfreeze(&volume->refcnt);
 	env_free(volume->priv);
 	return -OCF_ERR_NO_MEM;
 }
@@ -137,6 +141,7 @@ void ocf_volume_move(ocf_volume_t volume, ocf_volume_t from)
 	volume->priv = from->priv;
 	volume->cache = from->cache;
 	volume->features = from->features;
+	volume->refcnt = from->refcnt;
 
 	/*
 	 * Deinitialize original volume without freeing resources.
@@ -221,9 +226,6 @@ int ocf_volume_is_atomic(ocf_volume_t volume)
 
 struct ocf_io *ocf_volume_new_io(ocf_volume_t volume)
 {
-	if (!volume->opened)
-		return NULL;
-
 	return ocf_io_new(volume);
 }
 
@@ -276,15 +278,31 @@ int ocf_volume_open(ocf_volume_t volume, void *volume_params)
 	if (ret)
 		return ret;
 
+	ocf_refcnt_unfreeze(&volume->refcnt);
 	volume->opened = true;
 
 	return 0;
 }
 
+static void ocf_volume_close_end(void *ctx)
+{
+	env_completion *cmpl = ctx;
+
+	env_completion_complete(cmpl);
+}
+
 void ocf_volume_close(ocf_volume_t volume)
 {
+	env_completion cmpl;
+
 	ENV_BUG_ON(!volume->type->properties->ops.close);
 	ENV_BUG_ON(!volume->opened);
+
+	env_completion_init(&cmpl);
+	ocf_refcnt_freeze(&volume->refcnt);
+	ocf_refcnt_register_zero_cb(&volume->refcnt, ocf_volume_close_end,
+			&cmpl);
+	env_completion_wait(&cmpl);
 
 	volume->type->properties->ops.close(volume);
 	volume->opened = false;

--- a/src/ocf_volume_priv.h
+++ b/src/ocf_volume_priv.h
@@ -8,6 +8,7 @@
 
 #include "ocf_env.h"
 #include "ocf_io_priv.h"
+#include "utils/utils_refcnt.h"
 
 struct ocf_volume_type {
 	const struct ocf_volume_properties *properties;
@@ -26,6 +27,7 @@ struct ocf_volume {
 		unsigned discard_zeroes:1;
 			/* true if reading discarded pages returns 0 */
 	} features;
+	struct ocf_refcnt refcnt;
 };
 
 int ocf_volume_type_init(struct ocf_volume_type **type,

--- a/src/utils/utils_refcnt.c
+++ b/src/utils/utils_refcnt.c
@@ -5,6 +5,14 @@
 
 #include "../utils/utils_refcnt.h"
 
+void ocf_refcnt_init(struct ocf_refcnt *rc)
+{
+	env_atomic_set(&rc->counter, 0);
+	env_atomic_set(&rc->freeze, 0);
+	env_atomic_set(&rc->callback, 0);
+	rc->cb = NULL;
+}
+
 void ocf_refcnt_dec(struct ocf_refcnt *rc)
 {
 	int val = env_atomic_dec_return(&rc->counter);

--- a/src/utils/utils_refcnt.h
+++ b/src/utils/utils_refcnt.h
@@ -19,6 +19,9 @@ struct ocf_refcnt
 	void *priv;
 };
 
+/* Initialize reference counter */
+void ocf_refcnt_init(struct ocf_refcnt *rc);
+
 /* Try to increment counter. Returns true if successfull, false if freezed */
 bool ocf_refcnt_inc(struct ocf_refcnt  *rc);
 


### PR DESCRIPTION
Volume close should not close underlying device until all
I/O targeting this volume are deallocated. To achieve this
a reference counter is added to volume. Counter value
matches number of I/O objects associated with volume. Counter
is freezed when volume is closed, blocking allocation of new
I/O objects.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/125)
<!-- Reviewable:end -->
