### PR TITLE
Rename 'printf' field name in logger ops to 'print'.

### DIFF
--- a/example/simple/src/ctx.c
+++ b/example/simple/src/ctx.c
@@ -180,7 +180,7 @@ static void ctx_metadata_updater_stop(ocf_metadata_updater_t mu)
  * Function prividing interface for printing to log used by OCF internals.
  * It can handle differently messages at varous log levels.
  */
-static int ctx_logger_printf(ocf_logger_t logger, ocf_logger_lvl_t lvl,
+static int ctx_logger_print(ocf_logger_t logger, ocf_logger_lvl_t lvl,
 		const char *fmt, va_list args)
 {
 	FILE *lfile = stdout;
@@ -254,7 +254,7 @@ static const struct ocf_ctx_config ctx_cfg = {
 		},
 
 		.logger = {
-			.printf = ctx_logger_printf,
+			.print = ctx_logger_print,
 			.dump_stack = ctx_logger_dump_stack,
 		},
 	},

--- a/inc/ocf_logger.h
+++ b/inc/ocf_logger.h
@@ -31,9 +31,9 @@ typedef enum {
 struct ocf_logger_ops {
 	int (*open)(ocf_logger_t logger);
 	void (*close)(ocf_logger_t logger);
-	int (*printf)(ocf_logger_t logger, ocf_logger_lvl_t lvl,
+	int (*print)(ocf_logger_t logger, ocf_logger_lvl_t lvl,
 			const char *fmt, va_list args);
-	int (*printf_rl)(ocf_logger_t logger, const char *func_name);
+	int (*print_rl)(ocf_logger_t logger, const char *func_name);
 	int (*dump_stack)(ocf_logger_t logger);
 };
 

--- a/src/ocf_logger.c
+++ b/src/ocf_logger.c
@@ -18,11 +18,11 @@ int ocf_log_raw(ocf_logger_t logger, ocf_logger_lvl_t lvl,
 	va_list args;
 	int ret = 0;
 
-	if (!logger->ops->printf)
+	if (!logger->ops->print)
 		return -ENOTSUP;
 
 	va_start(args, fmt);
-	ret = logger->ops->printf(logger, lvl, fmt, args);
+	ret = logger->ops->print(logger, lvl, fmt, args);
 	va_end(args);
 
 	return ret;
@@ -30,10 +30,10 @@ int ocf_log_raw(ocf_logger_t logger, ocf_logger_lvl_t lvl,
 
 int ocf_log_raw_rl(ocf_logger_t logger, const char *func_name)
 {
-	if (!logger->ops->printf_rl)
+	if (!logger->ops->print_rl)
 		return -ENOTSUP;
 
-	return logger->ops->printf_rl(logger, func_name);
+	return logger->ops->print_rl(logger, func_name);
 }
 
 /*

--- a/src/ocf_trace.c
+++ b/src/ocf_trace.c
@@ -77,7 +77,7 @@ int ocf_mngt_start_trace(ocf_cache_t cache, void *trace_ctx,
 	ocf_trace_callback_t trace_callback)
 {
 	ocf_queue_t queue;
-	int result;
+	int result = 0;
 
 	OCF_CHECK_NULL(cache);
 

--- a/tests/functional/pyocf/types/logger.py
+++ b/tests/functional/pyocf/types/logger.py
@@ -52,14 +52,14 @@ class LoggerOps(Structure):
     CLOSE = CFUNCTYPE(None, c_void_p)
     # PRINTF ommited - we cannot make variadic function call in ctypes
     LOG = CFUNCTYPE(c_int, c_void_p, c_uint, c_char_p)
-    PRINTF_RL = CFUNCTYPE(c_int, c_void_p, c_char_p)
+    PRINT_RL = CFUNCTYPE(c_int, c_void_p, c_char_p)
     DUMP_STACK = CFUNCTYPE(c_int, c_void_p)
 
     _fields_ = [
         ("_open", OPEN),
         ("_close", CLOSE),
-        ("_printf", c_void_p),
-        ("_printf_rl", PRINTF_RL),
+        ("_print", c_void_p),
+        ("_print_rl", PRINT_RL),
         ("_dump_stack", DUMP_STACK),
     ]
 


### PR DESCRIPTION
Due the aggresive security checks in compiler 'printf' might be substituded with
'__printf_chk'. However it does not differentiate whether substituted string is
library function call whether filed in structure.

By renaming filed we prevent it to be unintentionally subustituted by the
preprocessor.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/ocf/126)
<!-- Reviewable:end -->
