### PR TITLE
pyocf: wait for pending I/O before cache stop

### DIFF
--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -409,6 +409,7 @@ class Cache:
             [("cache", c_void_p), ("priv", c_void_p), ("error", c_int)]
         )
 
+        self.owner.lib.ocf_cache_wait_for_io_finish(self.cache_handle)
         self.owner.lib.ocf_mngt_cache_stop(self.cache_handle, c, None)
 
         c.wait()


### PR DESCRIPTION
Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>