### PR TITLE
Fix cores volumes dropping before close

### DIFF
--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -141,7 +141,9 @@ class Core:
     def set_seq_cut_off_policy(self, policy: SeqCutOffPolicy):
         self.cache.get_and_write_lock()
 
-        status = self.cache.owner.lib.ocf_mngt_core_set_seq_cutoff_policy(self.handle, policy)
+        status = self.cache.owner.lib.ocf_mngt_core_set_seq_cutoff_policy(
+            self.handle, policy
+        )
         if status:
             self.cache.put_and_write_unlock()
             raise OcfError("Error setting core seq cut off policy", status)

--- a/tests/functional/pyocf/types/queue.py
+++ b/tests/functional/pyocf/types/queue.py
@@ -104,5 +104,3 @@ class Queue:
         if self.mngt_queue:
             OcfLib.getInstance().ocf_queue_put(self)
 
-        self.thread = None
-        self.ops = None

--- a/tests/functional/pyocf/types/volume.py
+++ b/tests/functional/pyocf/types/volume.py
@@ -131,6 +131,7 @@ class Volume(Structure):
         instance = cls._instances_[ref]()
         if instance is None:
             print("tried to access {} but it's gone".format(ref))
+
         return instance
 
     @classmethod

--- a/tests/functional/tests/conftest.py
+++ b/tests/functional/tests/conftest.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import pytest
+import gc
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 from pyocf.types.logger import LogLevel, DefaultLogger, BufferLogger
@@ -24,6 +25,7 @@ def pyocf_ctx():
     c.register_volume_type(ErrorDevice)
     yield c
     c.exit()
+    gc.collect()
 
 
 @pytest.fixture()
@@ -34,3 +36,4 @@ def pyocf_ctx_log_buffer():
     c.register_volume_type(ErrorDevice)
     yield logger
     c.exit()
+    gc.collect()


### PR DESCRIPTION
* Add references to Cores in Cache, ctx holds caches, caches hold cores,
  everything gets cleaned up nicely

* GC in Python seems to be a bit lazy, if we want to run CI on
  low-memory machines we need to make sure it does run in between tests
  'cause we don't want no huge Volumes hanging around for long

Signed-off-by: Jan Musial <jan.musial@intel.com>