### PR TITLE
Rename makefile ENV* variables to OCF_ENV*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ else
 $(error Not allowed program command)
 endif
 
-ifneq ($(strip $(ENV)),)
-ifeq ($(strip $(ENV)),posix)
-ENVDIR=$(PWD)/env/posix
+ifneq ($(strip $(OCF_ENV)),)
+ifeq ($(strip $(OCF_ENV)),posix)
+OCF_ENV_DIR=$(PWD)/env/posix
 else
 $(error Invalid environment selected)
 endif
@@ -79,30 +79,30 @@ $(SRC_RM): validate
 #
 # Installing environment
 #
-ENV_IN=$(shell find $(ENVDIR) -name '*.[c|h]' -type f)
-ENV_OUT=$(patsubst $(ENVDIR)%,$(OUTDIR)/src/ocf/env/%,$(ENV_IN))
-ENV_RM=$(shell find $(OUTDIR)/src/ocf/env -name '*.[c|h]' -xtype l 2>/dev/null)
+OCF_ENV_IN=$(shell find $(OCF_ENV_DIR) -name '*.[c|h]' -type f)
+OCF_ENV_OUT=$(patsubst $(OCF_ENV_DIR)%,$(OUTDIR)/src/ocf/env/%,$(OCF_ENV_IN))
+OCF_ENV_RM=$(shell find $(OUTDIR)/src/ocf/env -name '*.[c|h]' -xtype l 2>/dev/null)
 
 env: | env_check env_dep
 	@$(MAKE) distcleandir
 
 env_check:
-ifeq ($(ENVDIR),)
+ifeq ($(OCF_ENV_DIR),)
 	$(error No environment selected)
 endif
 
-env_dep: $(ENV_OUT) $(ENV_RM)
+env_dep: $(OCF_ENV_OUT) $(OCF_ENV_RM)
 
-$(ENV_OUT):
+$(OCF_ENV_OUT):
 ifeq ($(strip $(OUTDIR)),)
 	$(error No output specified for installing sources)
 endif
 	@echo " INSTALL  $@"
 	@mkdir -p $(dir $@)
-	@$(INSTALL) $(subst $(OUTDIR)/src/ocf/env,$(ENVDIR),$@) $@
+	@$(INSTALL) $(subst $(OUTDIR)/src/ocf/env,$(OCF_ENV_DIR),$@) $@
 
-$(ENV_RM): validate
-	$(if $(shell readlink $@ | grep $(ENVDIR)), \
+$(OCF_ENV_RM): validate
+	$(if $(shell readlink $@ | grep $(OCF_ENV_DIR)), \
 		@echo "  RM      $@"; rm $@,)
 
 #
@@ -134,4 +134,4 @@ doc: validate
 	@cd doc && mv html $(OUTDIR)/doc/ocf
 
 .PHONY: inc src env env_check env_dep validate help distclean distcleandir doc \
-    $(INC_RM) $(SRC_RM) $(ENV_RM) $(DIST_DIR)
+    $(INC_RM) $(SRC_RM) $(OCF_ENV_RM) $(DIST_DIR)

--- a/tests/build/Makefile
+++ b/tests/build/Makefile
@@ -27,7 +27,7 @@ build: $(OBJS)
 sync:
 	@$(MAKE) -C ${OCFDIR} inc O=$(PWD)
 	@$(MAKE) -C ${OCFDIR} src O=$(PWD)
-	@$(MAKE) -C ${OCFDIR} env O=$(PWD) ENV=posix
+	@$(MAKE) -C ${OCFDIR} env O=$(PWD) OCF_ENV=posix
 
 clean:
 	@rm -rf $(OBJS)

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -34,7 +34,7 @@ sync:
 	@mkdir -p $(ADAPTERDIR)/ocf
 	@$(MAKE) -C $(OCFDIR) inc O=$(ADAPTERDIR)/ocf
 	@$(MAKE) -C $(OCFDIR) src O=$(ADAPTERDIR)/ocf
-	@$(MAKE) -C $(OCFDIR) env O=$(ADAPTERDIR)/ocf ENV=posix
+	@$(MAKE) -C $(OCFDIR) env O=$(ADAPTERDIR)/ocf OCF_ENV=posix
 
 clean:
 	@rm -rf $(OCFLIB) $(OBJS)


### PR DESCRIPTION
'ENV' variable is set and used by OS utilities  on some Linux
distros, interfering with OCF build system. Renaming ENV and
other ENV* variables to OCF_ENV* to avoid conflicts.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>