### PR TITLE
Remove "interruption" argument from flush() functions

### DIFF
--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -532,11 +532,10 @@ typedef void (*ocf_mngt_cache_flush_end_t)(ocf_cache_t cache,
  * @brief Flush data from given cache
  *
  * @param[in] cache Cache handle
- * @param[in] interruption Allow for interruption
  * @param[in] cmpl Completion callback
  * @param[in] priv Completion callback context
  */
-void ocf_mngt_cache_flush(ocf_cache_t cache, bool interruption,
+void ocf_mngt_cache_flush(ocf_cache_t cache,
 		ocf_mngt_cache_flush_end_t cmpl, void *priv);
 
 /**
@@ -553,11 +552,10 @@ typedef void (*ocf_mngt_core_flush_end_t)(ocf_core_t core,
  * @brief Flush data to given core
  *
  * @param[in] core Core handle
- * @param[in] interruption Allow for interruption
  * @param[in] cmpl Completion callback
  * @param[in] priv Completion callback context
  */
-void ocf_mngt_core_flush(ocf_core_t core, bool interruption,
+void ocf_mngt_core_flush(ocf_core_t core,
 		ocf_mngt_core_flush_end_t cmpl, void *priv);
 
 /**

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2291,8 +2291,7 @@ static void ocf_mngt_cache_detach_flush(ocf_pipeline_t pipeline,
 	struct ocf_mngt_cache_detach_context *context = priv;
 	ocf_cache_t cache = context->cache;
 
-	ocf_mngt_cache_flush(cache, true, ocf_mngt_cache_detach_flush_cmpl,
-			context);
+	ocf_mngt_cache_flush(cache, ocf_mngt_cache_detach_flush_cmpl, context);
 }
 
 static void ocf_mngt_cache_detach_wait_pending(ocf_pipeline_t pipeline,

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -505,7 +505,7 @@ class Cache:
         c = OcfCompletion(
             [("cache", c_void_p), ("priv", c_void_p), ("error", c_int)]
         )
-        self.owner.lib.ocf_mngt_cache_flush(self.cache_handle, False, c, None)
+        self.owner.lib.ocf_mngt_cache_flush(self.cache_handle, c, None)
         c.wait()
         if c.results["error"]:
             self.put_and_write_unlock()


### PR DESCRIPTION
As non-interruptible flushes are no longer triggered from OCF
internals, we can get rid of "interruption" argument and let
adapters handle it themselves.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>