### PR TITLE
Fix compilation error

### DIFF
--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -595,8 +595,8 @@ static void ocf_mngt_cache_remove_core_flush_sb_complete(void *priv, int error)
 {
 	struct ocf_mngt_cache_remove_core_context *context = priv;
 
-	OCF_PL_NEXT_ON_SUCCESS_RET(context->pipeline,
-			error ? -OCF_ERR_WRITE_CACHE : 0);
+	error = error ? -OCF_ERR_WRITE_CACHE : 0;
+	OCF_PL_NEXT_ON_SUCCESS_RET(context->pipeline, error);
 }
 
 static void _ocf_mngt_cache_remove_core(ocf_pipeline_t pipeline, void *priv,


### PR DESCRIPTION
Passing int constant directly to OCF_PL_NEXT_ON_SUCCESS_RET() macro caused
following compilation error (on GCC 7.4.0):

src/ocf/mngt/ocf_mngt_core.c:599:33: error: ?:
using integer constants in boolean context [-Werror=int-in-bool-context]
    error ? -OCF_ERR_WRITE_CACHE : 0);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
src/ocf/mngt/../utils/utils_pipeline.h:145:6: note:
in definition of macro ‘OCF_PL_NEXT_ON_SUCCESS_RET’
  if (error) \
      ^~~~~

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>