### PR TITLE
Set core_id during load if user did not specify one

### DIFF
--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -316,6 +316,11 @@ static int __ocf_mngt_try_find_core_id(ocf_cache_t cache,
 		return -OCF_ERR_CORE_NOT_AVAIL;
 	}
 
+	if (cfg->core_id == OCF_CORE_MAX) {
+		cfg->core_id = tmp_core_id;
+		return 0;
+	}
+
 	if (cfg->core_id != tmp_core_id) {
 		ocf_cache_log(cache, log_err,
 				"Given core id doesn't match with metadata\n");


### PR DESCRIPTION
If cfg->core_id is OCF_CORE_MAX and that core matches the UUID of
existing not opened one, then set cfg->core_id to id of that core.

This is useful when loading cache from metadata: if user does not store
the ids of cores but relies on OCF to assign them, there is no need to
not reassign them on load.

Previus behaviur when cfg->core_id != id of core with matching UUID is
maintained.

Signed-off-by: Vitaliy Mysak <vitaliy.mysak@intel.com>