### PR TITLE
Exported object MD5 update

### DIFF
--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -158,21 +158,31 @@ class Core:
         logging.getLogger("pyocf").warning(
             "Reading whole exported object! This disturbs statistics values"
         )
-        read_buffer = Data(self.device.size)
-        io = self.new_io()
-        io.configure(0, read_buffer.size, IoDir.READ, 0, 0)
-        io.set_data(read_buffer)
-        io.set_queue(self.cache.get_default_queue())
+        cache_line_size = int(self.cache.get_stats()['conf']['cache_line_size'])
+        read_buffer_all = Data(self.device.size)
 
-        cmpl = OcfCompletion([("err", c_int)])
-        io.callback = cmpl.callback
-        io.submit()
-        cmpl.wait()
+        read_buffer = Data(cache_line_size)
 
-        if cmpl.results["err"]:
-            raise Exception("Error reading whole exported object")
+        position = 0
+        while position < read_buffer_all.size:
 
-        return read_buffer.md5()
+            io = self.new_io()
+            io.configure(position, cache_line_size, IoDir.READ, 0, 0)
+            io.set_data(read_buffer)
+            io.set_queue(self.cache.get_default_queue())
+
+            cmpl = OcfCompletion([("err", c_int)])
+            io.callback = cmpl.callback
+            io.submit()
+            cmpl.wait()
+
+            if cmpl.results["err"]:
+                raise Exception("Error reading whole exported object")
+
+            read_buffer_all.copy(read_buffer, position, 0, cache_line_size)
+            position += cache_line_size
+
+        return read_buffer_all.md5()
 
 
 lib = OcfLib.getInstance()

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -180,7 +180,7 @@ def test_stop(pyocf_ctx, mode: CacheMode, cls: CacheLineSize, with_flush: bool):
     run_io_and_cache_data_if_possible(core_exported, mode, cls)
 
     stats = cache.get_stats()
-    assert int(stats["conf"]["dirty"]) == (1 if mode == CacheMode.WB else 0), "Dirty data before MD5"
+    assert int(stats["conf"]["dirty"]) == (4 if mode == CacheMode.WB else 0), "Dirty data before MD5"
 
     md5_exported_core = core_exported.exp_obj_md5()
 
@@ -189,7 +189,6 @@ def test_stop(pyocf_ctx, mode: CacheMode, cls: CacheLineSize, with_flush: bool):
     cache.stop()
 
     if mode == CacheMode.WB and not with_flush:
-        pytest.xfail("MD5 sums equal without flush with dirty data")  # TODO: remove after WB fixed
         assert core_device.md5() != md5_exported_core, \
             "MD5 check: core device vs exported object with dirty data"
     else:
@@ -344,20 +343,20 @@ def test_start_too_small_device(pyocf_ctx, mode, cls):
 
 
 def run_io_and_cache_data_if_possible(exported_obj, mode, cls):
-    test_data = Data.from_string("This is test data")
+    test_data = Data.from_string("x"*cls*4)
 
     if mode in {CacheMode.WI, CacheMode.WA}:
         logger.info("[STAGE] Write to core device")
-        io_to_core(exported_obj, test_data, 20, True)
+        io_to_core(exported_obj, test_data, cls, True)
         logger.info("[STAGE] Read from exported object")
-        io_from_exported_object(exported_obj, test_data.size, 20)
+        io_from_exported_object(exported_obj, test_data.size, cls)
     else:
         logger.info("[STAGE] Write to exported object")
-        io_to_core(exported_obj, test_data, 20)
+        io_to_core(exported_obj, test_data, cls)
 
     stats = exported_obj.cache.get_stats()
     assert stats["usage"]["occupancy"]["value"] == \
-        ((cls / CacheLineSize.LINE_4KiB) if mode != CacheMode.PT else 0), "Occupancy"
+        ((test_data.size / CacheLineSize.LINE_4KiB) if mode != CacheMode.PT else 0), "Occupancy"
 
 
 def io_to_core(exported_obj: Core, data: Data, offset: int, to_core_device=False):


### PR DESCRIPTION
Reading one CLS at a time for exported object MD5 calculation.
Fully dirty cache lines will not be cleaned on read.

Signed-off-by: Daniel Madej <daniel.madej@intel.com>