### PR TITLE
metadata: Put io before callback invocation

### DIFF
--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -168,12 +168,12 @@ static void ocf_metadata_read_sb_complete(struct ocf_io *io, int error)
 				sizeof(context->superblock));
 	}
 
+	ctx_data_free(context->ctx, data);
+	ocf_io_put(io);
 
 	context->error = error;
 	context->cmpl(context);
 
-	ctx_data_free(context->ctx, data);
-	ocf_io_put(io);
 	env_free(context);
 }
 


### PR DESCRIPTION
This allows for safe volume destruction in callback function.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>