### PR TITLE
Fix order of operations in cache stop completion

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -1976,10 +1976,10 @@ static void ocf_mngt_cache_stop_finish(ocf_pipeline_t pipeline,
 				context->cache_name);
 	}
 
+	ocf_pipeline_destroy(context->pipeline);
+
 	context->cmpl(cache, context->priv,
 			error ?: context->cache_write_error);
-
-	ocf_pipeline_destroy(context->pipeline);
 
 	if (!error) {
 		/* Finally release cache instance */


### PR DESCRIPTION
If callback is called before destruction of pipeline this scenario is
possible and was occuring in some cases in pyocf tests:
1. Stop all caches
2. After completion, exit the context
3. Pipeline is destroyed, request tries to deallocate itself (also, put
queues etc) but context along with allocators is no longer there

Signed-off-by: Jan Musial <jan.musial@intel.com>