### PR TITLE
Create config which excludes tests marked as "long" and security tests by default

### DIFF
--- a/tests/functional/pytest.ini
+++ b/tests/functional/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=tests/security -m "not long"


### PR DESCRIPTION
Signed-off-by: Kamil Lepek <kamil.lepek94@gmail.com>