### PR TITLE
Initialize @increment in ocf_read_wo_cache_do

### DIFF
--- a/src/engine/engine_wo.c
+++ b/src/engine/engine_wo.c
@@ -62,7 +62,7 @@ static int ocf_read_wo_cache_do(struct ocf_request *req)
 	uint64_t phys_prev, phys_curr = 0;
 	uint64_t io_start = 0;
 	uint64_t offset = 0;
-	uint64_t increment;
+	uint64_t increment = 0;
 
 	env_atomic_set(&req->req_remaining, 1);
 


### PR DESCRIPTION
Static code analyzers fail to understand that this variable
is always assigned to before usage.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>