### PR TITLE
Revert "Disallow ocf_cache_mode_max in io_class config"

### DIFF
--- a/src/mngt/ocf_mngt_io_class.c
+++ b/src/mngt/ocf_mngt_io_class.c
@@ -236,7 +236,7 @@ static int _ocf_mngt_io_class_validate_cfg(ocf_cache_t cache,
 		return 0;
 
 	if (cfg->cache_mode < ocf_cache_mode_none ||
-			cfg->cache_mode >= ocf_cache_mode_max) {
+			cfg->cache_mode > ocf_cache_mode_max) {
 		return -OCF_ERR_INVAL;
 	}
 


### PR DESCRIPTION
This reverts commit 5ad5c521df650ea8d12e38c7060f61f1ab8285b3.

This change broke setting IO-classes with allocation. We use max as a
special value to indicate that the partition should use cache global
caching mode.