### PR TITLE
Forcing symbolic link creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(strip $(OUTDIR)),)
 endif
 
 ifeq ($(strip $(CMD)),)
-INSTALL=ln -s
+INSTALL=ln -fs
 else ifeq ($(strip $(CMD)),cp)
 INSTALL=cp
 else ifeq ($(strip $(CMD)),install)


### PR DESCRIPTION
This fixes problem with building Open CAS with '-j' flag.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>