### PR TITLE
Remove cache dirty check at flush completion

### DIFF
--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -606,6 +606,15 @@ void ocf_mngt_cache_flush(ocf_cache_t cache,
 		ocf_mngt_cache_flush_end_t cmpl, void *priv);
 
 /**
+ * @brief Check if cache is dirty
+ *
+ * @param[in] cache Cache handle
+ *
+ * @retval true if cache is dirty, false otherwise
+ */
+bool ocf_mngt_cache_is_dirty(ocf_cache_t cache);
+
+/**
  * @brief Completion callback of core flush operation
  *
  * @param[in] core Core handle

--- a/src/mngt/ocf_mngt_common.h
+++ b/src/mngt/ocf_mngt_common.h
@@ -21,8 +21,6 @@ int _ocf_cleaning_thread(void *priv);
 
 int cache_mngt_thread_io_requests(void *data);
 
-bool ocf_mngt_cache_is_dirty(ocf_cache_t cache);
-
 int ocf_mngt_add_partition_to_cache(struct ocf_cache *cache,
 		ocf_part_id_t part_id, const char *name, uint32_t min_size,
 		uint32_t max_size, uint8_t priority, bool valid);

--- a/src/mngt/ocf_mngt_flush.c
+++ b/src/mngt/ocf_mngt_flush.c
@@ -598,20 +598,6 @@ static void _ocf_mngt_flush_finish(ocf_pipeline_t pipeline, void *priv,
 	ocf_cache_t cache = context->cache;
 	ocf_core_t core = context->core;
 
-	if (!error) {
-		switch(context->op) {
-		case flush_cache:
-		case purge_cache:
-			ENV_BUG_ON(ocf_mngt_cache_is_dirty(cache));
-			break;
-		case flush_core:
-		case purge_core:
-			ENV_BUG_ON(env_atomic_read(
-					&core->runtime_meta->dirty_clines));
-			break;
-		}
-	}
-
 	_ocf_mngt_end_flush(cache);
 
 	switch (context->op) {


### PR DESCRIPTION
When flush completion is called there could be some clines marked as dirty since those could be in-use during flushing.