### PR TITLE
Prevent warpping ocf_mngt_cache_mode_has_lazy_write() in UT.

### DIFF
--- a/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
+++ b/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
@@ -8,6 +8,7 @@
 
 /*
 <functions_to_leave>
+ocf_mngt_cache_mode_has_lazy_write
 </functions_to_leave>
 */
 


### PR DESCRIPTION
Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>