### PR TITLE
Add promotion policy API and use it in I/O path

### DIFF
--- a/inc/ocf_def.h
+++ b/inc/ocf_def.h
@@ -193,7 +193,7 @@ typedef enum {
 } ocf_seq_cutoff_policy;
 
 /**
- * OCF supported eviction types
+ * OCF supported eviction policy types
  */
 typedef enum {
 	ocf_eviction_lru = 0,
@@ -205,6 +205,23 @@ typedef enum {
 	ocf_eviction_default = ocf_eviction_lru,
 		/*!< Default eviction policy */
 } ocf_eviction_t;
+
+/**
+ * OCF supported promotion policy types
+ */
+typedef enum {
+	ocf_promotion_nop = 0,
+		/*!< No promotion policy. Cache inserts are not filtered */
+
+	ocf_promotion_nhit,
+		/*!< Line can be inserted after N requests for it */
+
+	ocf_promotion_max,
+		/*!< Stopper of enumerator */
+
+	ocf_promotion_default = ocf_promotion_nop,
+		/*!< Default promotion policy */
+} ocf_promotion_t;
 
 /**
  * OCF supported Write-Back cleaning policies type

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -263,6 +263,11 @@ struct ocf_mngt_cache_config {
 	ocf_eviction_t eviction_policy;
 
 	/**
+	 * @brief Promotion policy type
+	 */
+	ocf_promotion_t promotion_policy;
+
+	/**
 	 * @brief Cache line size
 	 */
 	ocf_cache_line_size_t cache_line_size;
@@ -313,6 +318,7 @@ static inline void ocf_mngt_cache_config_set_default(
 	cfg->name = NULL;
 	cfg->cache_mode = ocf_cache_mode_default;
 	cfg->eviction_policy = ocf_eviction_default;
+	cfg->promotion_policy = ocf_promotion_default;
 	cfg->cache_line_size = ocf_cache_line_size_4;
 	cfg->metadata_layout = ocf_metadata_layout_default;
 	cfg->metadata_volatile = false;

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -60,6 +60,8 @@ static void _ocf_discard_core_complete(struct ocf_io *io, int error)
 
 	OCF_DEBUG_RQ(req, "Core DISCARD Completion");
 
+	ocf_promotion_req_purge(req->cache->promotion_policy, req);
+
 	_ocf_discard_complete_req(req, error);
 
 	ocf_io_put(io);

--- a/src/engine/engine_rd.c
+++ b/src/engine/engine_rd.c
@@ -269,7 +269,7 @@ int ocf_read_generic(struct ocf_request *req)
 		 */
 		ocf_engine_map(req);
 
-		if (!req->info.eviction_error) {
+		if (!req->info.mapping_error) {
 			if (ocf_engine_is_hit(req)) {
 				/* After mapping turns out there is hit,
 				 * so lock OCF request for read access
@@ -287,7 +287,7 @@ int ocf_read_generic(struct ocf_request *req)
 		/*- END Metadata WR access -----------------------------------*/
 	}
 
-	if (!req->info.eviction_error) {
+	if (!req->info.mapping_error) {
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* Lock was not acquired, need to wait for resume */

--- a/src/engine/engine_wb.c
+++ b/src/engine/engine_wb.c
@@ -204,7 +204,7 @@ int ocf_write_wb(struct ocf_request *req)
 		 */
 		ocf_engine_map(req);
 
-		if (!req->info.eviction_error) {
+		if (!req->info.mapping_error) {
 			/* Lock request for WRITE access */
 			lock = ocf_req_trylock_wr(req);
 		}
@@ -212,7 +212,7 @@ int ocf_write_wb(struct ocf_request *req)
 		OCF_METADATA_UNLOCK_WR(); /*- END Metadata WR access ---------*/
 	}
 
-	if (!req->info.eviction_error) {
+	if (!req->info.mapping_error) {
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* WR lock was not acquired, need to wait for resume */

--- a/src/engine/engine_wt.c
+++ b/src/engine/engine_wt.c
@@ -197,7 +197,7 @@ int ocf_write_wt(struct ocf_request *req)
 		 */
 		ocf_engine_map(req);
 
-		if (!req->info.eviction_error) {
+		if (!req->info.mapping_error) {
 			/* Lock request for WRITE access */
 			lock = ocf_req_trylock_wr(req);
 		}
@@ -205,7 +205,7 @@ int ocf_write_wt(struct ocf_request *req)
 		OCF_METADATA_UNLOCK_WR(); /*- END Metadata WR access ---------*/
 	}
 
-	if (!req->info.eviction_error) {
+	if (!req->info.mapping_error) {
 		if (lock >= 0) {
 			if (lock != OCF_LOCK_ACQUIRED) {
 				/* WR lock was not acquired, need to wait for resume */

--- a/src/eviction/eviction.c
+++ b/src/eviction/eviction.c
@@ -118,6 +118,6 @@ int space_managment_evict_do(struct ocf_cache *cache,
 	if (evict_cline_no <= evicted)
 		return LOOKUP_MAPPED;
 
-	req->info.eviction_error |= true;
+	req->info.mapping_error |= true;
 	return LOOKUP_MISS;
 }

--- a/src/metadata/metadata_superblock.h
+++ b/src/metadata/metadata_superblock.h
@@ -6,6 +6,9 @@
 #ifndef __METADATA_SUPERBLOCK_H__
 #define __METADATA_SUPERBLOCK_H__
 
+#include "../eviction/eviction.h"
+#include "../promotion/promotion.h"
+
 #define CACHE_MAGIC_NUMBER	0x187E1CA6
 
 /**
@@ -38,6 +41,7 @@ struct ocf_superblock_config {
 	struct cleaning_policy_config cleaning[CLEANING_POLICY_TYPE_MAX];
 
 	ocf_eviction_t eviction_policy_type;
+	ocf_promotion_t promotion_policy_type;
 
 	/* Current core sequence number */
 	ocf_core_id_t curr_core_seq_no;

--- a/src/ocf_cache_priv.h
+++ b/src/ocf_cache_priv.h
@@ -20,6 +20,7 @@
 #include "cleaning/cleaning.h"
 #include "ocf_logger_priv.h"
 #include "ocf/ocf_trace.h"
+#include "promotion/promotion.h"
 
 #define DIRTY_FLUSHED 1
 #define DIRTY_NOT_FLUSHED 0
@@ -149,6 +150,7 @@ struct ocf_cache {
 
 	struct ocf_cleaner cleaner;
 	struct ocf_metadata_updater metadata_updater;
+	ocf_promotion_policy_t promotion_policy;
 
 	struct ocf_async_lock lock;
 

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -30,8 +30,8 @@ struct ocf_req_info {
 	uint32_t flush_metadata : 1;
 	/*!< This bit tells if metadata flushing is required */
 
-	uint32_t eviction_error : 1;
-	/*!< Eviction error flag */
+	uint32_t mapping_error : 1;
+	/*!< Core lines in this request were not mapped into cache */
 
 	uint32_t re_part : 1;
 	/*!< This bit indicate that in the request some cache lines

--- a/src/promotion/nhit.c
+++ b/src/promotion/nhit.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include "../metadata/metadata.h"
+
+#include "nhit.h"
+
+ocf_error_t nhit_init(ocf_cache_t cache, ocf_promotion_policy_t policy)
+{
+	return 0;
+}
+
+void nhit_deinit(ocf_promotion_policy_t policy)
+{
+
+}
+
+ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
+		uint64_t param_value)
+{
+	return 0;
+}
+
+void nhit_req_purge(ocf_promotion_policy_t policy,
+		struct ocf_request *req)
+{
+
+}
+
+bool nhit_req_should_promote(ocf_promotion_policy_t policy, struct ocf_request *req)
+{
+	return true;
+}
+

--- a/src/promotion/nhit.h
+++ b/src/promotion/nhit.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef NHIT_PROMOTION_POLICY_H_
+#define NHIT_PROMOTION_POLICY_H_
+
+#include "ocf/ocf.h"
+#include "../ocf_request.h"
+#include "promotion.h"
+
+ocf_error_t nhit_init(ocf_cache_t cache, ocf_promotion_policy_t policy);
+
+void nhit_deinit(ocf_promotion_policy_t policy);
+
+ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
+		uint64_t param_value);
+
+void nhit_req_purge(ocf_promotion_policy_t policy,
+		struct ocf_request *req);
+
+bool nhit_req_should_promote(ocf_promotion_policy_t policy,
+		struct ocf_request *req);
+
+#endif /* NHIT_PROMOTION_POLICY_H_ */

--- a/src/promotion/ops.h
+++ b/src/promotion/ops.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef PROMOTION_OPS_H_
+#define PROMOTION_OPS_H_
+
+#include "../metadata/metadata.h"
+#include "promotion.h"
+
+struct ocf_promotion_policy {
+	ocf_promotion_t type;
+	void *ctx;
+};
+
+struct promotion_policy_ops {
+	const char *name;
+		/*!< Promotion policy name */
+
+	ocf_error_t (*init)(ocf_cache_t cache, ocf_promotion_policy_t policy);
+		/*!< Allocate and initialize promotion policy */
+
+	void (*deinit)(ocf_promotion_policy_t policy);
+		/*!< Deinit and free promotion policy */
+
+	ocf_error_t (*set_param)(ocf_promotion_policy_t policy, uint8_t param_id,
+			uint64_t param_value);
+		/*!< Set promotion policy parameter */
+
+	void (*req_purge)(ocf_promotion_policy_t policy,
+			struct ocf_request *req);
+		/*!< Call when request core lines have been inserted or it is
+		 * a discard request */
+
+	bool (*req_should_promote)(ocf_promotion_policy_t policy,
+			struct ocf_request *req);
+		/*!< Should request lines be inserted into cache */
+};
+
+#endif /* PROMOTION_OPS_H_ */
+

--- a/src/promotion/promotion.c
+++ b/src/promotion/promotion.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include "../metadata/metadata.h"
+
+#include "promotion.h"
+#include "ops.h"
+#include "nhit.h"
+
+struct promotion_policy_ops ocf_promotion_policies[ocf_promotion_max] = {
+	[ocf_promotion_nop] = {
+		.name = "nop",
+	},
+	[ocf_promotion_nhit] = {
+		.name = "nhit",
+		.init = nhit_init,
+		.deinit = nhit_deinit,
+		.set_param = nhit_set_param,
+		.req_purge = nhit_req_purge,
+		.req_should_promote = nhit_req_should_promote,
+	},
+};
+
+ocf_error_t ocf_promotion_init(ocf_cache_t cache, ocf_promotion_policy_t *policy)
+{
+	ocf_promotion_t type = cache->conf_meta->promotion_policy_type;
+	ocf_error_t result = 0;
+
+	ENV_BUG_ON(type >= ocf_promotion_max);
+
+	*policy = env_vmalloc(sizeof(**policy));
+	if (!*policy)
+		return -OCF_ERR_NO_MEM;
+
+	(*policy)->type = type;
+
+	if (ocf_promotion_policies[type].init)
+		result = ocf_promotion_policies[type].init(cache, *policy);
+
+	return result;
+}
+
+void ocf_promotion_deinit(ocf_promotion_policy_t policy)
+{
+	ocf_promotion_t type = policy->type;
+
+	ENV_BUG_ON(type >= ocf_promotion_max);
+
+	if (ocf_promotion_policies[type].deinit)
+		ocf_promotion_policies[type].deinit(policy);
+
+	env_vfree(policy);
+}
+
+ocf_error_t ocf_promotion_set_param(ocf_promotion_policy_t policy,
+		uint8_t param_id, uint64_t param_value)
+{
+	ocf_promotion_t type = policy->type;
+	ocf_error_t result = 0;
+
+	ENV_BUG_ON(type >= ocf_promotion_max);
+
+	if (ocf_promotion_policies[type].set_param) {
+		result = ocf_promotion_policies[type].set_param(policy, param_id,
+				param_value);
+	}
+
+	return result;
+}
+
+void ocf_promotion_req_purge(ocf_promotion_policy_t policy,
+		struct ocf_request *req)
+{
+	ocf_promotion_t type = policy->type;
+
+	ENV_BUG_ON(type >= ocf_promotion_max);
+
+	if (ocf_promotion_policies[type].req_purge)
+		ocf_promotion_policies[type].req_purge(policy, req);
+}
+
+bool ocf_promotion_req_should_promote(ocf_promotion_policy_t policy,
+		struct ocf_request *req)
+{
+	ocf_promotion_t type = policy->type;
+	bool result = true;
+
+	ENV_BUG_ON(type >= ocf_promotion_max);
+
+	if (ocf_promotion_policies[type].req_should_promote) {
+		result = ocf_promotion_policies[type].req_should_promote(policy,
+				req);
+	}
+
+	return result;
+}
+

--- a/src/promotion/promotion.h
+++ b/src/promotion/promotion.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef PROMOTION_H_
+#define PROMOTION_H_
+
+#include "ocf/ocf.h"
+#include "../ocf_request.h"
+
+typedef struct ocf_promotion_policy *ocf_promotion_policy_t;
+/**
+ * @brief Allocate and initialize promotion policy. Should be called after cache
+ * metadata has been allocated and cache->conf_meta->promotion_policy_type has
+ * been set.
+ *
+ * @param[in] cache OCF cache instance
+ * @param[out] param initialized policy handle
+ *
+ * @retval ocf_error_t
+ */
+ocf_error_t ocf_promotion_init(ocf_cache_t cache, ocf_promotion_policy_t *policy);
+
+/**
+ * @brief Stop, deinitialize and free promotion policy structures.
+ *
+ * @param[in] policy promotion policy handle
+ *
+ * @retval none
+ */
+void ocf_promotion_deinit(ocf_promotion_policy_t policy);
+
+/**
+ * @brief Set promotion policy parameter
+ *
+ * @param[in] policy promotion policy handle
+ * @param[in] param_id id of parameter to be set
+ * @param[in] param_value value of parameter to be set
+ *
+ * @retval ocf_error_t
+ */
+ocf_error_t ocf_promotion_set_param(ocf_promotion_policy_t policy,
+		uint8_t param_id, uint64_t param_value);
+
+/**
+ * @brief Update promotion policy after cache lines have been promoted to cache
+ * or discarded from core device
+ *
+ * @param[in] policy promotion policy handle
+ * @param[in] req OCF request to be purged
+ *
+ * @retval none
+ */
+void ocf_promotion_req_purge(ocf_promotion_policy_t policy,
+		struct ocf_request *req);
+
+/**
+ * @brief Check in promotion policy whether core lines in request can be promoted
+ *
+ * @param[in] policy promotion policy handle
+ * @param[in] req OCF request which is to be promoted
+ *
+ * @retval should core lines belonging to this request be promoted
+ */
+bool ocf_promotion_req_should_promote(ocf_promotion_policy_t policy,
+		struct ocf_request *req);
+
+#endif /* PROMOTION_H_ */

--- a/src/utils/utils_cache_line.c
+++ b/src/utils/utils_cache_line.c
@@ -4,6 +4,7 @@
  */
 
 #include "utils_cache_line.h"
+#include "../promotion/promotion.h"
 
 static inline void ocf_cleaning_set_hot_cache_line(struct ocf_cache *cache,
 		ocf_cache_line_t line)

--- a/src/utils/utils_cache_line.h
+++ b/src/utils/utils_cache_line.h
@@ -7,9 +7,9 @@
 #define UTILS_CACHE_LINE_H_
 
 #include "../metadata/metadata.h"
+#include "../concurrency/ocf_cache_concurrency.h"
 #include "../eviction/eviction.h"
 #include "../eviction/ops.h"
-#include "../concurrency/ocf_cache_concurrency.h"
 #include "../engine/cache_engine.h"
 #include "../ocf_request.h"
 #include "../ocf_def_priv.h"

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -46,6 +46,7 @@ class CacheConfig(Structure):
         ("_name", c_char_p),
         ("_cache_mode", c_uint32),
         ("_eviction_policy", c_uint32),
+        ("_promotion_policy", c_uint32),
         ("_cache_line_size", c_uint64),
         ("_metadata_layout", c_uint32),
         ("_metadata_volatile", c_bool),
@@ -92,6 +93,12 @@ class EvictionPolicy(IntEnum):
     DEFAULT = LRU
 
 
+class PromotionPolicy(IntEnum):
+    NOP = 0
+    NHIT = 1
+    DEFAULT = NOP
+
+
 class CleaningPolicy(IntEnum):
     NOP = 0
     ALRU = 1
@@ -131,6 +138,7 @@ class Cache:
         name: str = "",
         cache_mode: CacheMode = CacheMode.DEFAULT,
         eviction_policy: EvictionPolicy = EvictionPolicy.DEFAULT,
+        promotion_policy: PromotionPolicy = PromotionPolicy.DEFAULT,
         cache_line_size: CacheLineSize = CacheLineSize.DEFAULT,
         metadata_layout: MetadataLayout = MetadataLayout.DEFAULT,
         metadata_volatile: bool = False,
@@ -150,6 +158,7 @@ class Cache:
             _name=name.encode("ascii") if name else None,
             _cache_mode=cache_mode,
             _eviction_policy=eviction_policy,
+            _promotion_policy=promotion_policy,
             _cache_line_size=cache_line_size,
             _metadata_layout=metadata_layout,
             _metadata_volatile=metadata_volatile,


### PR DESCRIPTION
Promotion policy is supposed to restrict which request's lines can be inserted into cache.
This is the first of its kind - nhit promotion policy. It will perform ALRU noise filtering by
eliminating one-hit wonders being added to cache and polluting it.

Signed-off-by: Jan Musial <jan.musial@intel.com>