### PR TITLE
Remove redundant field from struct ocf_cache_device

### DIFF
--- a/src/metadata/metadata_hash.c
+++ b/src/metadata/metadata_hash.c
@@ -965,7 +965,6 @@ finalize:
 				ctrl->raw_desc[metadata_segment_hash].entries;
 
 		cache->device->metadata_offset = ctrl->count_pages * PAGE_SIZE;
-		cache->device->metadata_offset_line = ctrl->count_pages;
 
 		cache->conf_meta->cachelines = ctrl->cachelines;
 		cache->conf_meta->line_size = cache_line_size;

--- a/src/ocf_cache.c
+++ b/src/ocf_cache.c
@@ -147,7 +147,7 @@ int ocf_cache_get_info(ocf_cache_t cache, struct ocf_cache_info *info)
 	info->occupancy = cache_occupancy_total;
 	info->dirty_for = _calc_dirty_for(dirty_since);
 	info->metadata_end_offset = ocf_cache_is_device_attached(cache) ?
-			cache->device->metadata_offset_line : 0;
+			cache->device->metadata_offset / PAGE_SIZE : 0;
 
 	info->state = cache->cache_state;
 	info->inactive.occupancy = cache_occupancy_inactive;

--- a/src/ocf_cache_priv.h
+++ b/src/ocf_cache_priv.h
@@ -66,8 +66,6 @@ enum ocf_mngt_cache_init_mode {
 struct ocf_cache_device {
 	struct ocf_volume volume;
 
-	ocf_cache_line_t metadata_offset_line;
-
 	/* Hash Table contains contains pointer to the entry in
 	 * Collision Table so it actually contains collision Table
 	 * indexes.


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>