### PR TITLE
After removing core from cache, reset 'added' flag.

### DIFF
--- a/src/mngt/ocf_mngt_common.c
+++ b/src/mngt/ocf_mngt_common.c
@@ -117,6 +117,7 @@ void cache_mngt_core_remove_from_cache(ocf_core_t core)
 	env_free(core->counters);
 	core->counters = NULL;
 	env_bit_clear(core_id, cache->conf_meta->valid_core_bitmap);
+	core->conf_meta->added = false;
 
 	if (!core->opened && --cache->ocf_core_inactive_count == 0)
 		env_bit_clear(ocf_cache_state_incomplete, &cache->cache_state);


### PR DESCRIPTION
for_each_core() macro iterates over cores using 'added' flag from core metadata.
When removing core, it wasn't reset.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>