### PR TITLE
Additional volume type ops: deinit.

### DIFF
--- a/inc/ocf_volume.h
+++ b/inc/ocf_volume.h
@@ -141,6 +141,9 @@ struct ocf_volume_properties {
 
 	struct ocf_io_ops io_ops;
 		/*!< IO operations */
+
+	void (*deinit)(void);
+		/*!< Deinitialize volume type */
 };
 
 /**

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -532,6 +532,7 @@ const struct ocf_volume_properties ocf_core_volume_properties = {
 		.set_data = ocf_core_io_set_data,
 		.get_data = ocf_core_io_get_data,
 	},
+	.deinit = NULL,
 };
 
 static int ocf_core_io_allocator_init(ocf_io_allocator_t allocator,
@@ -583,9 +584,4 @@ int ocf_core_volume_type_init(ocf_ctx_t ctx)
 	return ocf_ctx_register_volume_type_extended(ctx, 0,
 			&ocf_core_volume_properties,
 			&ocf_core_volume_extended);
-}
-
-void ocf_core_volume_type_deinit(ocf_ctx_t ctx)
-{
-	ocf_ctx_unregister_volume_type(ctx, 0);
 }

--- a/src/ocf_core_priv.h
+++ b/src/ocf_core_priv.h
@@ -95,6 +95,4 @@ bool ocf_core_is_valid(ocf_cache_t cache, ocf_core_id_t id);
 
 int ocf_core_volume_type_init(ocf_ctx_t ctx);
 
-void ocf_core_volume_type_deinit(ocf_ctx_t ctx);
-
 #endif /* __OCF_CORE_PRIV_H__ */

--- a/src/ocf_ctx.c
+++ b/src/ocf_ctx.c
@@ -209,6 +209,17 @@ void ocf_ctx_get(ocf_ctx_t ctx)
 /*
  *
  */
+static void ocf_ctx_unregister_volume_types(ocf_ctx_t ctx)
+{
+	int id;
+
+	for (id = 0; id < OCF_VOLUME_TYPE_MAX; id++)
+		ocf_ctx_unregister_volume_type(ctx, id);
+}
+
+/*
+ *
+ */
 void ocf_ctx_put(ocf_ctx_t ctx)
 {
 	OCF_CHECK_NULL(ctx);
@@ -221,7 +232,7 @@ void ocf_ctx_put(ocf_ctx_t ctx)
 	env_rmutex_unlock(&ctx->lock);
 
 	ocf_mngt_core_pool_deinit(ctx);
-	ocf_core_volume_type_deinit(ctx);
+	ocf_ctx_unregister_volume_types(ctx);
 	ocf_req_allocator_deinit(ctx);
 	ocf_logger_close(&ctx->logger);
 	env_free(ctx);

--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -59,6 +59,9 @@ err:
 
 void ocf_volume_type_deinit(struct ocf_volume_type *type)
 {
+	if (type->properties->deinit)
+		type->properties->deinit();
+
 	ocf_io_allocator_deinit(&type->allocator);
 	env_free(type);
 }

--- a/tests/functional/pyocf/types/volume.py
+++ b/tests/functional/pyocf/types/volume.py
@@ -66,6 +66,7 @@ class VolumeProperties(Structure):
         ("_caps", VolumeCaps),
         ("_ops", VolumeOps),
         ("_io_ops", IoOps),
+        ("_deinit", c_char_p),
     ]
 
 
@@ -125,6 +126,7 @@ class Volume(Structure):
                 _io_ops=IoOps(
                     _set_data=cls._io_set_data, _get_data=cls._io_get_data
                 ),
+                _deinit=0,
             )
 
         return cls.props


### PR DESCRIPTION
Adapter can't deinitialize volume types before deinitializing core pool.
Additional callback allows ocf to perform this operations in appropriate order.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>