### PR TITLE
pyocf: Fix tests to send io aligned to sector size

### DIFF
--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -32,8 +32,8 @@ def test_simple_wt_write(pyocf_ctx):
     core_device.reset_stats()
 
     write_data = Data.from_string("This is test data")
-    io = core.new_io(cache.get_default_queue(), 20, write_data.size,
-                     IoDir.WRITE, 0, 0)
+    io = core.new_io(cache.get_default_queue(), S.from_sector(1).B,
+                     write_data.size, IoDir.WRITE, 0, 0)
     io.set_data(write_data)
 
     cmpl = OcfCompletion([("err", c_int)])

--- a/tests/functional/tests/management/test_add_remove.py
+++ b/tests/functional/tests/management/test_add_remove.py
@@ -102,7 +102,8 @@ def test_10add_remove_with_io(pyocf_ctx):
 
         write_data = Data.from_string("Test data")
         io = core.new_io(
-            cache.get_default_queue(), 20, write_data.size, IoDir.WRITE, 0, 0
+            cache.get_default_queue(), S.from_sector(1).B, write_data.size,
+            IoDir.WRITE, 0, 0
         )
         io.set_data(write_data)
 

--- a/tests/functional/tests/security/test_secure_erase.py
+++ b/tests/functional/tests/security/test_secure_erase.py
@@ -88,7 +88,8 @@ def test_secure_erase_simple_io_read_misses(cache_mode):
 
     write_data = Data.from_string("This is test data")
     io = core.new_io(
-        cache.get_default_queue(), 20, write_data.size, IoDir.WRITE, 0, 0
+        cache.get_default_queue(), S.from_sector(1).B, write_data.size,
+        IoDir.WRITE, 0, 0
     )
     io.set_data(write_data)
 


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>