### PR TITLE
Intro to ocf_env documentation and ocf_env unify

### DIFF
--- a/doc/doxygen_ocf_env.cfg
+++ b/doc/doxygen_ocf_env.cfg
@@ -1,0 +1,329 @@
+# Doxyfile 1.8.6
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "Open CAS Framework"
+PROJECT_NUMBER         =
+PROJECT_BRIEF          = "Open source framework of Cache Acceleration Software"
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = .
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 8
+ALIASES                =
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = YES
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = YES
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = ../env HOME_ocf_env.md
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.c \
+                         *.h \
+                         *.md
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             = ./img/
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE = HOME_ocf_env.md
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html_ocf_env
+HTML_FILE_EXTENSION    = .html
+#HTML_HEADER            = header.html
+#HTML_FOOTER            = footer.html
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+PERL_PATH              = /usr/bin/perl
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/env/posix/ocf_env.c
+++ b/env/posix/ocf_env.c
@@ -3,18 +3,25 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
+/**
+ * @file
+ * @brief OCF 
+ * 
+ * 
+ */
+
 #include "ocf_env.h"
 #include <sched.h>
 #include <execinfo.h>
 
 struct _env_allocator {
-	/*!< Memory pool ID unique name */
+	/*! Memory pool ID unique name */
 	char *name;
 
-	/*!< Size of specific item of memory pool */
+	/*! Size of specific item of memory pool */
 	uint32_t item_size;
 
-	/*!< Number of currently allocated items in pool */
+	/*! Number of currently allocated items in pool */
 	env_atomic count;
 };
 
@@ -45,7 +52,6 @@ void *env_allocator_new(env_allocator *allocator)
 	return &item->data;
 }
 
-
 env_allocator *env_allocator_create(uint32_t size, const char *fmt_name, ...)
 {
 	char name[OCF_ALLOCATOR_NAME_MAX] = { '\0' };
@@ -60,7 +66,7 @@ env_allocator *env_allocator_create(uint32_t size, const char *fmt_name, ...)
 
 	allocator->item_size = size + sizeof(struct _env_allocator_item);
 
-	/* Format allocator name */
+	/*! Format allocator name */
 	va_start(args, fmt_name);
 	result = vsnprintf(name, sizeof(name), fmt_name, args);
 	va_end(args);

--- a/env/posix/ocf_env.h
+++ b/env/posix/ocf_env.h
@@ -54,7 +54,6 @@ typedef uint64_t u64;
 typedef uint64_t sector_t;
 
 #define __packed	__attribute__((packed))
-#define __aligned(x)	__attribute__((aligned(x)))
 
 #define likely(cond)       __builtin_expect(!!(cond), 1)
 #define unlikely(cond)     __builtin_expect(!!(cond), 0)
@@ -69,7 +68,6 @@ typedef uint64_t sector_t;
 
 #define ENV_WARN(cond, fmt...)		printf(fmt)
 #define ENV_WARN_ON(cond)		;
-#define ENV_WARN_ONCE(cond, fmt...)	ENV_WARN(cond, fmt)
 
 #define ENV_BUG()			assert(0)
 #define ENV_BUG_ON(cond)		do { if (cond) ENV_BUG(); } while (0)
@@ -77,7 +75,6 @@ typedef uint64_t sector_t;
 /* *** MEMORY MANAGEMENT *** */
 #define ENV_MEM_NORMAL	0
 #define ENV_MEM_NOIO	0
-#define ENV_MEM_ATOMIC	0
 
 static inline void *env_malloc(size_t size, int flags)
 {
@@ -519,25 +516,6 @@ static inline void env_rwlock_destroy(env_rwlock *l)
 	ENV_BUG_ON(pthread_rwlock_destroy(&l->lock));
 }
 
-/* *** WAITQUEUE *** */
-
-typedef struct {
-	sem_t sem;
-} env_waitqueue;
-
-#define env_waitqueue_wait(w, condition)	\
-({						\
-	int __ret = 0;				\
-	if (!(condition))			\
-		sem_wait(&w.sem);		\
-	__ret = __ret;				\
-})
-
-static inline void env_waitqueue_destroy(env_waitqueue *w)
-{
-	sem_destroy(&w->sem);
-}
-
 /* *** BIT OPERATIONS *** */
 
 static inline void env_bit_set(int nr, volatile void *addr)
@@ -619,7 +597,6 @@ static inline void env_sort(void *base, size_t num, size_t size,
 		*diff = memcmp(s1, s2, min(s1max, s2max)); \
 		0; \
 	})
-#define env_strdup strndup
 #define env_strnlen(s, smax) strnlen(s, smax)
 #define env_strncmp strncmp
 #define env_strncpy(dest, dmax, src, slen) ({ \

--- a/env/posix/ocf_env.h
+++ b/env/posix/ocf_env.h
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
+/**
+ * @file
+ * @brief OCF environment functions and macros
+ * 
+ * This file contains definitions for many OCF functions
+ * and sets macros
+ */
+
 #ifndef __OCF_ENV_H__
 #define __OCF_ENV_H__
 
@@ -15,12 +23,9 @@
 
 #include <linux/limits.h>
 #include <linux/stddef.h>
-#include <stdint.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <stddef.h>
 #include <string.h>
 #include <pthread.h>
 #include <assert.h>

--- a/env/posix/ocf_env_headers.h
+++ b/env/posix/ocf_env_headers.h
@@ -7,7 +7,7 @@
  * @file
  * @brief OCF libs and macros
  *
- * Header file with OCF common libraries and macros.
+ * This file is mostly to aggregate external header includes.
  */
 #ifndef __OCF_ENV_HEADERS_H__
 #define __OCF_ENV_HEADERS_H__
@@ -17,7 +17,7 @@
 #include <stdbool.h>
 
 /* TODO: Move prefix printing to context logger. */
-#define OCF_LOGO "Intel(R) OCF"
+#define OCF_LOGO ""
 #define OCF_PREFIX_SHORT "[" OCF_LOGO "] "
 #define OCF_PREFIX_LONG "Open CAS Framework"
 

--- a/env/posix/ocf_env_headers.h
+++ b/env/posix/ocf_env_headers.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
+/**
+ * @file
+ * @brief OCF libs and macros
+ *
+ * Header file with OCF common libraries and macros.
+ */
 #ifndef __OCF_ENV_HEADERS_H__
 #define __OCF_ENV_HEADERS_H__
 

--- a/env/posix/ocf_env_list.h
+++ b/env/posix/ocf_env_list.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
+/**
+ * @file
+ * @brief OCF lists
+ *
+ * Header file for OCF which contains customized list types.
+ */
 #ifndef __OCF_ENV_LIST__
 #define __OCF_ENV_LIST__
 
@@ -165,4 +171,4 @@ static inline void list_move_tail(struct list_head *it, struct list_head *l1)
 		     _list_entry_helper(item, (plist)->next, field_name); \
 	     item = q, q = _list_entry_helper(q, (q)->field_name.next, field_name))
 
-#endif // __OCF_ENV_LIST__
+#endif /* __OCF_ENV_LIST__ */

--- a/inc/ocf_metadata.h
+++ b/inc/ocf_metadata.h
@@ -30,7 +30,7 @@ struct ocf_atomic_metadata {
 
 	/** Set bit indicates that sector i dirty */
 	uint32_t dirty : 1;
-} __attribute__((packed));
+} __packed;
 
 #define OCF_ATOMIC_METADATA_SIZE	sizeof(struct ocf_atomic_metadata)
 

--- a/inc/ocf_types.h
+++ b/inc/ocf_types.h
@@ -4,9 +4,12 @@
  */
 
 /**
- * @file
- * @brief OCF types
- */
+* @file
+* @brief OCF types
+*
+* This file contains data types for whole OCF.
+*/
+
 #ifndef __OCF_TYPES_H_
 #define __OCF_TYPES_H_
 

--- a/src/cleaning/alru_structs.h
+++ b/src/cleaning/alru_structs.h
@@ -13,7 +13,7 @@ struct alru_cleaning_policy_meta {
 	uint32_t timestamp;
 	uint32_t lru_prev;
 	uint32_t lru_next;
-} __attribute__((packed));
+} __packed;
 
 struct alru_cleaning_policy_config {
 	uint32_t thread_wakeup_time;	/* in seconds */

--- a/src/cleaning/nop_structs.h
+++ b/src/cleaning/nop_structs.h
@@ -7,7 +7,7 @@
 #define __LAYER_CLEANING_POLICY_NOP_STRUCTS_H__
 
 struct nop_cleaning_policy_meta {
-} __attribute__((packed));
+} __packed;
 
 struct nop_cleaning_policy {
 };

--- a/src/eviction/eviction.h
+++ b/src/eviction/eviction.h
@@ -23,7 +23,7 @@ struct eviction_policy {
 /* Eviction policy metadata per cache line */
 union eviction_policy_meta {
 	struct lru_eviction_policy_meta lru;
-} __attribute__((packed));
+} __packed;
 
 /* the caller must hold the metadata lock for all operations
  *

--- a/tests/unit/framework/add_new_test_file.py
+++ b/tests/unit/framework/add_new_test_file.py
@@ -90,7 +90,7 @@ class TestGenerator(object):
     def get_autowrap_file_include(self, test_file_path):
         autowrap_file = test_file_path.rsplit(".", 1)[0]
         autowrap_file = autowrap_file.replace(self.main_UT_dir, "")
-        autowrap_file += "_generated_warps.c"
+        autowrap_file += "_generated_wraps.c"
         return "#include \"" + autowrap_file + "\"\n\n"
 
     def get_includes(self, abs_path_to_tested_file):

--- a/tests/unit/framework/prepare_sources_for_testing.py
+++ b/tests/unit/framework/prepare_sources_for_testing.py
@@ -141,7 +141,7 @@ class UnitTestsSourcesGenerator(object):
 
     def get_autowrap_file_path(self, test_file_path):
         wrap_file_path = test_file_path.rsplit('.', 1)[0]
-        wrap_file_path = wrap_file_path + "_generated_warps.c"
+        wrap_file_path = wrap_file_path + "_generated_wraps.c"
         return wrap_file_path
 
     def prepare_autowraps(self, test_file_path, preprocessed_file_path):
@@ -695,10 +695,32 @@ class UnitTestsSourcesGenerator(object):
 
         self.main_tested_dir = main_tested_dir
 
+    def add_test_flag(self):
+        for dest in self.includes_to_copy_dict:
+            if os.path.isfile(self.get_main_UT_dir() + dest + 'ocf.h'):
+                with open(self.get_main_UT_dir() + dest + 'ocf.h', 'r') as ocf:
+                    lines = ocf.readlines()
+                    lines[3] += '\n#define TEST\n'
+                    ocf.close()
+                with open(self.get_main_UT_dir() + dest + 'ocf.h', 'w') as ocf:
+                    ocf.writelines(lines)
+                    ocf.close()
+        for hdr in self.tests_internal_includes_list:
+            if os.path.isfile(hdr + 'ocf_env.h'):
+                with open(hdr + 'ocf_env.h', 'r') as ocf:
+                    lines = ocf.readlines()
+                    if ('#define TEST' not in lines[5]):
+                        lines[3] += '\n#define TEST\n'
+                    ocf.close()
+                with open(hdr + 'ocf_env.h', 'w') as ocf:
+                    ocf.writelines(lines)
+                    ocf.close()
+
 
 def __main__():
     generator = UnitTestsSourcesGenerator()
     generator.copy_includes()
+    generator.add_test_flag()
     generator.preprocessing()
     generator.prepare_sources_for_testing()
     generator.create_main_cmake_lists()

--- a/tests/unit/tests/add_new_test_file.py
+++ b/tests/unit/tests/add_new_test_file.py
@@ -15,7 +15,7 @@ framework_script_path = os.path.join(script_path, "../framework/add_new_test_fil
 framework_script_path = os.path.normpath(framework_script_path)
 status, output = commands.getstatusoutput(framework_script_path + " " + args)
 
-print output
+print(output)
 
 if status == 0:
     path = output.split(" ", 1)[0]

--- a/tests/unit/tests/cleaning/alru.c/cleaning_policy_alru_initialize_part_test.c
+++ b/tests/unit/tests/cleaning/alru.c/cleaning_policy_alru_initialize_part_test.c
@@ -35,7 +35,7 @@
 #include "../concurrency/ocf_cache_line_concurrency.h"
 #include "../ocf_def_priv.h"
 
-#include "cleaning/alru.c/cleaning_policy_alru_initialize_part_test_generated_warps.c"
+#include "cleaning/alru.c/cleaning_policy_alru_initialize_part_test_generated_wraps.c"
 
 
 static void cleaning_policy_alru_initialize_test01(void **state)

--- a/tests/unit/tests/cleaning/cleaning.c/ocf_cleaner_run_test.c
+++ b/tests/unit/tests/cleaning/cleaning.c/ocf_cleaner_run_test.c
@@ -35,7 +35,7 @@
 #include "../mngt/ocf_mngt_common.h"
 #include "../metadata/metadata.h"
 
-#include "cleaning/cleaning.c/ocf_cleaner_run_test_generated_warps.c"
+#include "cleaning/cleaning.c/ocf_cleaner_run_test_generated_wraps.c"
 
 /*
  * Mocked functions. Here we must deliver functions definitions which are not

--- a/tests/unit/tests/metadata/metadata_collision.c/metadata_collision.c
+++ b/tests/unit/tests/metadata/metadata_collision.c/metadata_collision.c
@@ -21,7 +21,7 @@
 #include "metadata.h"
 #include "../utils/utils_cache_line.h"
 
-#include "metadata/metadata_collision.c/metadata_collision_generated_warps.c"
+#include "metadata/metadata_collision.c/metadata_collision_generated_wraps.c"
 
 static void metadata_hash_func_test01(void **state)
 {

--- a/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
+++ b/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
@@ -40,7 +40,7 @@ ocf_mngt_cache_mode_has_lazy_write
 #include "../ocf_ctx_priv.h"
 #include "../cleaning/cleaning.h"
 
-#include "mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test_generated_warps.c"
+#include "mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test_generated_wraps.c"
 /*
  * Mocked functions
  */

--- a/tests/unit/tests/mngt/ocf_mngt_cache.c/ocf_mngt_cache_set_fallback_pt_error_threshold.c
+++ b/tests/unit/tests/mngt/ocf_mngt_cache.c/ocf_mngt_cache_set_fallback_pt_error_threshold.c
@@ -34,7 +34,7 @@
 #include "../ocf_ctx_priv.h"
 #include "../cleaning/cleaning.h"
 
-#include "mngt/ocf_mngt_cache.c/ocf_mngt_cache_set_fallback_pt_error_threshold_generated_warps.c"
+#include "mngt/ocf_mngt_cache.c/ocf_mngt_cache_set_fallback_pt_error_threshold_generated_wraps.c"
 
 int __wrap_ocf_log_raw(ocf_logger_t logger, ocf_logger_lvl_t lvl,
 		const char *fmt, ...)

--- a/tests/unit/tests/mngt/ocf_mngt_io_class.c/ocf_mngt_io_class.c
+++ b/tests/unit/tests/mngt/ocf_mngt_io_class.c/ocf_mngt_io_class.c
@@ -35,7 +35,7 @@
 #include "../eviction/ops.h"
 #include "ocf_env.h"
 
-#include "mngt/ocf_mngt_io_class.c/ocf_mngt_io_class_generated_warps.c"
+#include "mngt/ocf_mngt_io_class.c/ocf_mngt_io_class_generated_wraps.c"
 
 /* Functions mocked for testing purposes */
 bool __wrap_ocf_part_is_added(struct ocf_user_part *part)

--- a/tests/unit/tests/ocf_env/ocf_env.c
+++ b/tests/unit/tests/ocf_env/ocf_env.c
@@ -3,21 +3,20 @@
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
-
 #include "ocf_env.h"
 #include <sys/types.h>
 
-#include <stdarg.h>
-#include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
 
+/* BUG ON */
 void bug_on(int cond)
 {
 	/*   Wrap this to use your implementation */
 	assert_false(cond);
 }
 
+/* MEMORY MANAGEMENT */
 void *env_malloc(size_t size, int flags)
 {
 	return malloc(size);
@@ -53,8 +52,7 @@ uint64_t env_get_free_memory(void)
 	return sysconf(_SC_PAGESIZE) * sysconf(_SC_AVPHYS_PAGES);
 }
 
-/* *** ALLOCATOR *** */
-
+/* ALLOCATOR */
 struct _env_allocator {
 	/*!< Memory pool ID unique name */
 	char *name;
@@ -127,8 +125,7 @@ void env_allocator_destroy(env_allocator *allocator)
 	}
 }
 
-/* *** COMPLETION *** */
-
+/* COMPLETION */
 void env_completion_init(env_completion *completion)
 {
 	function_called();
@@ -147,7 +144,7 @@ void env_completion_complete(env_completion *completion)
 	check_expected_ptr(completion);
 }
 
-
+/* MUTEX */
 int env_mutex_init(env_mutex *mutex)
 {
 	function_called();
@@ -174,6 +171,7 @@ void env_mutex_unlock(env_mutex *mutex)
 	check_expected_ptr(mutex);
 }
 
+/* RECURSIVE MUTEX */
 int env_rmutex_init(env_rmutex *rmutex)
 {
 	function_called();
@@ -200,6 +198,7 @@ void env_rmutex_unlock(env_rmutex *rmutex)
 	check_expected_ptr(rmutex);
 }
 
+/* RW SEMAPHORE */
 int env_rwsem_init(env_rwsem *s)
 {
 	function_called();
@@ -245,6 +244,7 @@ int env_rwsem_down_write_trylock(env_rwsem *s)
 	return mock();
 }
 
+/* ATOMIC VARIABLES */
 int env_atomic_read(const env_atomic *a)
 {
 	return *a;
@@ -361,6 +361,7 @@ long env_atomic64_cmpxchg(env_atomic64 *a, long old, long new)
 	return oldval;
 }
 
+/* SPIN LOCKS */
 void env_spinlock_init(env_spinlock *l)
 {
 	function_called();
@@ -379,6 +380,7 @@ void env_spinlock_unlock(env_spinlock *l)
 	check_expected_ptr(l);
 }
 
+/* RW LOCKS */
 void env_rwlock_init(env_rwlock *l)
 {
 	function_called();
@@ -409,6 +411,7 @@ void env_rwlock_write_unlock(env_rwlock *l)
 	check_expected_ptr(l);
 }
 
+/* BIT OPERATIONS */
 void env_bit_set(int nr, volatile void *addr)
 {
 	char *byte = (char *) addr + (nr >> 3);
@@ -434,8 +437,7 @@ bool env_bit_test(int nr, const volatile unsigned long *addr)
 	return !!(*byte & mask);
 }
 
-/* *** SCHEDULING *** */
-
+/* SCHEDULING */
 void env_touch_softlockup_wd(void)
 {
 	function_called();
@@ -469,6 +471,7 @@ uint64_t env_secs_to_ticks(uint64_t j)
 	return j * 1000;
 }
 
+/* STRING OPERATIONS */
 int env_memset(void *dest, size_t count, int ch)
 {
 	memset(dest, ch, count);
@@ -482,7 +485,6 @@ int env_memcpy(void *dest, size_t destsz, const void * src, size_t count)
 	else
 		memcpy(dest, src, count);
 	return 0;
-
 }
 
 int env_memcmp(const void *str1, size_t n1, const void *str2, size_t n2,
@@ -520,13 +522,12 @@ int env_strncmp(const char * str1, const char * str2, size_t num)
 	return strncmp(str1, str2, num);
 }
 
+/* TIME */
 void env_msleep(uint64_t n)
 {
-
 }
 
-/* *** CRC *** */
-
+/* CRC */
 uint32_t env_crc32(uint32_t crc, uint8_t const *data, size_t len)
 {
 	function_called();

--- a/tests/unit/tests/ocf_env/ocf_env.h
+++ b/tests/unit/tests/ocf_env/ocf_env.h
@@ -38,10 +38,9 @@ typedef uint64_t u64;
 
 typedef uint64_t sector_t;
 
-#define ENV_PRIu64 "lu"
+#define __packed	__attribute__((packed))
 
-#define __packed __attribute__((packed))
-#define __aligned(x) __attribute__((aligned(x)))
+#define ENV_PRIu64 "lu"
 
 /* linux sector 512-bytes */
 #define ENV_SECTOR_SHIFT	9
@@ -54,7 +53,6 @@ typedef uint64_t sector_t;
 
 #define ENV_MEM_NORMAL	0
 #define ENV_MEM_NOIO	1
-#define ENV_MEM_ATOMIC	2
 
 #define ENV_WARN(cond, fmt, args...) ({})
 

--- a/tests/unit/tests/ocf_env/ocf_env.h
+++ b/tests/unit/tests/ocf_env/ocf_env.h
@@ -1,7 +1,17 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
+
+/**
+ * @file
+ * @brief OCF environment functions and macros
+ * 
+ * This file contains definitions for OCF POSIX environment functions and macros.
+ */
+
+#ifndef __OCF_ENV_H__
+#define __OCF_ENV_H__
 
 #ifndef __LIBOCF_ENV_H__
 #define __LIBOCF_ENV_H__
@@ -15,9 +25,7 @@
 
 #include <linux/limits.h>
 #include <linux/stddef.h>
-#include <stdint.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -27,9 +35,19 @@
 #include <errno.h>
 #include <limits.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <sys/time.h>
+#include <sys/param.h>
+#include <sys/mman.h>
+#include <zlib.h>
 
 #include "ocf_env_list.h"
+#include "ocf_env_headers.h"
+
+/* *** COMMON MACROS *** */
+
+/* linux sector 512-bytes */
+#define ENV_SECTOR_SHIFT	9
 
 typedef uint8_t u8;
 typedef uint16_t u16;
@@ -42,20 +60,82 @@ typedef uint64_t sector_t;
 
 #define ENV_PRIu64 "lu"
 
-/* linux sector 512-bytes */
-#define ENV_SECTOR_SHIFT	9
-
 #define PAGE_SIZE 4096
+
+/* *** COMMON MACROS END *** */
+
+
+/* *** REGULAR MACROS *** */
+#ifndef TEST
+
+#include "ocf/ocf_err.h"
+
+#define likely(cond)       __builtin_expect(!!(cond), 1)
+#define unlikely(cond)     __builtin_expect(!!(cond), 0)
+
+#define min(a,b) MIN(a,b)
+
+#define OCF_ALLOCATOR_NAME_MAX 128
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+/* STRING OPERATIONS */
+#define env_memset(dest, dmax, val) ({ \
+		memset(dest, val, dmax); \
+		0; \
+	})
+#define env_memcpy(dest, dmax, src, slen) ({ \
+		memcpy(dest, src, min(dmax, slen)); \
+		0; \
+	})
+#define env_memcmp(s1, s1max, s2, s2max, diff) ({ \
+		*diff = memcmp(s1, s2, min(s1max, s2max)); \
+		0; \
+	})
+#define env_strnlen(s, smax) strnlen(s, smax)
+#define env_strncmp strncmp
+#define env_strncpy(dest, dmax, src, slen) ({ \
+		strncpy(dest, src, min(dmax, slen)); \
+		0; \
+	})
+
+/* DEBUGING */
+#define ENV_WARN(cond, fmt...)		printf(fmt)
+#define ENV_WARN_ON(cond)		;
+
+#define ENV_BUG()			assert(0)
+#define ENV_BUG_ON(cond)		do { if (cond) ENV_BUG(); } while (0)
+
+/* MEMORY MANAGEMENT */
+#define ENV_MEM_NORMAL	0
+#define ENV_MEM_NOIO	0
+
+#endif	/* *** REGULAR MACROS *** */
+
+
+/* *** UNIT TESTS' ONLY MACROS *** */
+#ifdef TEST
+
+#define likely(x) (x)
+#define unlikely(x) (x)
 
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
 
-/* *** MEMORY MANAGEMENT *** */
+/* ATOMICS */
+#ifndef atomic_read
+#define atomic_read(ptr)       (*(__typeof__(*ptr) *volatile) (ptr))
+#endif
 
+#ifndef atomic_set
+#define atomic_set(ptr, i)     ((*(__typeof__(*ptr) *volatile) (ptr)) = (i))
+#endif
+
+/* MEMORY MANAGEMENT */
 #define ENV_MEM_NORMAL	0
 #define ENV_MEM_NOIO	1
 
+/* DEBUGING */
 #define ENV_WARN(cond, fmt, args...) ({})
-
 #define ENV_WARN_ON(cond) ({ \
 		if (unlikely(cond)) \
 			fprintf(stderr, "WARNING (%s:%d)\n", \
@@ -68,30 +148,549 @@ typedef uint64_t sector_t;
 		assert(0); \
 		abort(); \
 	})
-
 #define ENV_BUG_ON(cond) bug_on((int)cond);
 
-#define container_of(ptr, type, member) ({                      \
-       const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
-       (type *)( (char *)__mptr - offsetof(type, member) );})
+#endif	/* *** UNIT TESTS ONLY MACROS *** */
 
-/* ATOMICS */
-#ifndef atomic_read
-#define atomic_read(ptr)       (*(__typeof__(*ptr) *volatile) (ptr))
-#endif
 
-#ifndef atomic_set
-#define atomic_set(ptr, i)     ((*(__typeof__(*ptr) *volatile) (ptr)) = (i))
-#endif
+/* *** COMMON FUNCTIONS' DECLARATIONS *** */
 
-#define likely(x) (x)
-#define unlikely(x) (x)
+/* ALLOCATOR */
+typedef struct _env_allocator env_allocator;
+
+void env_allocator_destroy(env_allocator *allocator);
+
+void *env_allocator_new(env_allocator *allocator);
+
+void env_allocator_del(env_allocator *allocator, void *item);
+
+/* MISC UTILITIES */
+#define container_of(ptr, type, member) ({          \
+	const typeof(((type *)0)->member)*__mptr = (ptr);    \
+	(type *)((char *)__mptr - offsetof(type, member)); })
+
+/* CRC */
+uint32_t env_crc32(uint32_t crc, uint8_t const *data, size_t len);
+
+/* *** COMMON FUNCTIONS' DECLARATIONS END *** */
+
+
+/* *** REGULAR FUNCTIONS' DECLARATIONS *** */
+#ifndef TEST
+
+/* MEMORY MANAGEMENT */
+static inline void *env_malloc(size_t size, int flags)
+{
+	return malloc(size);
+}
+
+static inline void *env_zalloc(size_t size, int flags)
+{
+	void *ptr = malloc(size);
+
+	if (ptr)
+		memset(ptr, 0, size);
+
+	return ptr;
+}
+
+static inline void env_free(const void *ptr)
+{
+	free((void *)ptr);
+}
+
+static inline void *env_vmalloc(size_t size)
+{
+	return malloc(size);
+}
+
+static inline void *env_vzalloc(size_t size)
+{
+	return env_zalloc(size, 0);
+}
+
+static inline void env_vfree(const void *ptr)
+{
+	free((void *)ptr);
+}
+
+/* SECURE MEMORY MANAGEMENT */
 
 /*
- * Bug on for testing
+ * OCF adapter can opt to take additional steps to securely allocate and free
+ * memory used by OCF to store cache metadata. This is to prevent other
+ * entities in the system from acquiring parts of OCF cache metadata via
+ * memory allocations. If this is not a concern in given product, secure
+ * alloc/free should default to vmalloc/vfree.
+ *
+ * Memory returned from secure alloc is not expected to be physically continous
+ * nor zeroed.
  */
+
+/* default to standard memory allocations for secure allocations */
+#define SECURE_MEMORY_HANDLING 0
+
+static inline void *env_secure_alloc(size_t size)
+{
+	void *ptr = malloc(size);
+
+#if SECURE_MEMORY_HANDLING
+	if (ptr && mlock(ptr, size)) {
+		free(ptr);
+		ptr = NULL;
+	}
+#endif
+
+	return ptr;
+}
+
+static inline void env_secure_free(const void *ptr, size_t size)
+{
+	if (ptr) {
+#if SECURE_MEMORY_HANDLING
+		memset(ptr, size, 0);
+		/* TODO: flush CPU caches ? */
+		ENV_BUG_ON(munlock(ptr));
+#endif
+		free((void*)ptr);
+	}
+}
+
+static inline uint64_t env_get_free_memory(void)
+{
+	return sysconf(_SC_PAGESIZE) * sysconf(_SC_AVPHYS_PAGES);
+}
+
+/* ALLOCATOR */
+env_allocator *env_allocator_create(uint32_t size, const char *fmt_name, ...);
+
+/* MUTEX */
+typedef struct {
+	pthread_mutex_t m;
+} env_mutex;
+
+#define env_cond_resched()      ({})
+
+static inline int env_mutex_init(env_mutex *mutex)
+{
+	if(pthread_mutex_init(&mutex->m, NULL))
+		return 1;
+
+	return 0;
+}
+
+static inline void env_mutex_lock(env_mutex *mutex)
+{
+	ENV_BUG_ON(pthread_mutex_lock(&mutex->m));
+}
+
+static inline int env_mutex_lock_interruptible(env_mutex *mutex)
+{
+	env_mutex_lock(mutex);
+	return 0;
+}
+
+static inline void env_mutex_unlock(env_mutex *mutex)
+{
+	ENV_BUG_ON(pthread_mutex_unlock(&mutex->m));
+}
+
+static inline int env_mutex_destroy(env_mutex *mutex)
+{
+	if(pthread_mutex_destroy(&mutex->m))
+		return 1;
+
+	return 0;
+}
+
+/* RECURSIVE MUTEX */
+typedef env_mutex env_rmutex;
+
+static inline int env_rmutex_init(env_rmutex *rmutex)
+{
+	pthread_mutexattr_t attr;
+
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&rmutex->m, &attr);
+
+	return 0;
+}
+
+static inline void env_rmutex_lock(env_rmutex *rmutex)
+{
+	env_mutex_lock(rmutex);
+}
+
+static inline int env_rmutex_lock_interruptible(env_rmutex *rmutex)
+{
+	return env_mutex_lock_interruptible(rmutex);
+}
+
+static inline void env_rmutex_unlock(env_rmutex *rmutex)
+{
+	env_mutex_unlock(rmutex);
+}
+
+static inline int env_rmutex_destroy(env_rmutex *rmutex)
+{
+	if(pthread_mutex_destroy(&rmutex->m))
+		return 1;
+
+	return 0;
+}
+
+/* RW SEMAPHORE */
+typedef struct {
+	 pthread_rwlock_t lock;
+} env_rwsem;
+
+static inline int env_rwsem_init(env_rwsem *s)
+{
+	return pthread_rwlock_init(&s->lock, NULL);
+}
+
+static inline void env_rwsem_up_read(env_rwsem *s)
+{
+	pthread_rwlock_unlock(&s->lock);
+}
+
+static inline void env_rwsem_down_read(env_rwsem *s)
+{
+	ENV_BUG_ON(pthread_rwlock_rdlock(&s->lock));
+}
+
+static inline int env_rwsem_down_read_trylock(env_rwsem *s)
+{
+	return pthread_rwlock_tryrdlock(&s->lock) ? -OCF_ERR_NO_LOCK : 0;
+}
+
+static inline void env_rwsem_up_write(env_rwsem *s)
+{
+	ENV_BUG_ON(pthread_rwlock_unlock(&s->lock));
+}
+
+static inline void env_rwsem_down_write(env_rwsem *s)
+{
+	ENV_BUG_ON(pthread_rwlock_wrlock(&s->lock));
+}
+
+static inline int env_rwsem_down_write_trylock(env_rwsem *s)
+{
+	return pthread_rwlock_trywrlock(&s->lock) ? -OCF_ERR_NO_LOCK : 0;
+}
+
+static inline int env_rwsem_destroy(env_rwsem *s)
+{
+	return pthread_rwlock_destroy(&s->lock);
+}
+
+/* COMPLETION */
+struct completion {
+	sem_t sem;
+};
+
+typedef struct completion env_completion;
+
+static inline void env_completion_init(env_completion *completion)
+{
+	sem_init(&completion->sem, 0, 0);
+}
+
+static inline void env_completion_wait(env_completion *completion)
+{
+	sem_wait(&completion->sem);
+}
+
+static inline void env_completion_complete(env_completion *completion)
+{
+	sem_post(&completion->sem);
+}
+
+static inline void env_completion_destroy(env_completion *completion)
+{
+	sem_destroy(&completion->sem);
+}
+
+/* ATOMIC VARIABLES */
+typedef struct {
+	volatile int counter;
+} env_atomic;
+
+typedef struct {
+	volatile long counter;
+} env_atomic64;
+
+static inline int env_atomic_read(const env_atomic *a)
+{
+	return a->counter; /* TODO */
+}
+
+static inline void env_atomic_set(env_atomic *a, int i)
+{
+	a->counter = i; /* TODO */
+}
+
+static inline void env_atomic_add(int i, env_atomic *a)
+{
+	__sync_add_and_fetch(&a->counter, i);
+}
+
+static inline void env_atomic_sub(int i, env_atomic *a)
+{
+	__sync_sub_and_fetch(&a->counter, i);
+}
+
+static inline void env_atomic_inc(env_atomic *a)
+{
+	env_atomic_add(1, a);
+}
+
+static inline void env_atomic_dec(env_atomic *a)
+{
+	env_atomic_sub(1, a);
+}
+
+static inline bool env_atomic_dec_and_test(env_atomic *a)
+{
+	return __sync_sub_and_fetch(&a->counter, 1) == 0;
+}
+
+static inline int env_atomic_add_return(int i, env_atomic *a)
+{
+	return __sync_add_and_fetch(&a->counter, i);
+}
+
+static inline int env_atomic_sub_return(int i, env_atomic *a)
+{
+	return __sync_sub_and_fetch(&a->counter, i);
+}
+
+static inline int env_atomic_inc_return(env_atomic *a)
+{
+	return env_atomic_add_return(1, a);
+}
+
+static inline int env_atomic_dec_return(env_atomic *a)
+{
+	return env_atomic_sub_return(1, a);
+}
+
+static inline int env_atomic_cmpxchg(env_atomic *a, int old, int new_value)
+{
+	return __sync_val_compare_and_swap(&a->counter, old, new_value);
+}
+
+static inline int env_atomic_add_unless(env_atomic *a, int i, int u)
+{
+	int c, old;
+	c = env_atomic_read(a);
+	for (;;) {
+		if (unlikely(c == (u)))
+			break;
+		old = env_atomic_cmpxchg((a), c, c + (i));
+		if (likely(old == c))
+			break;
+		c = old;
+	}
+	return c != (u);
+}
+
+static inline long env_atomic64_read(const env_atomic64 *a)
+{
+	return a->counter; /* TODO */
+}
+
+static inline void env_atomic64_set(env_atomic64 *a, long i)
+{
+	a->counter = i; /* TODO */
+}
+
+static inline void env_atomic64_add(long i, env_atomic64 *a)
+{
+	__sync_add_and_fetch(&a->counter, i);
+}
+
+static inline void env_atomic64_sub(long i, env_atomic64 *a)
+{
+	__sync_sub_and_fetch(&a->counter, i);
+}
+
+static inline void env_atomic64_inc(env_atomic64 *a)
+{
+	env_atomic64_add(1, a);
+}
+
+static inline void env_atomic64_dec(env_atomic64 *a)
+{
+	env_atomic64_sub(1, a);
+}
+
+static inline long env_atomic64_inc_return(env_atomic64 *a)
+{
+	return __sync_add_and_fetch(&a->counter, 1);
+}
+
+static inline long env_atomic64_cmpxchg(env_atomic64 *a, long old_v, long new_v)
+{
+	return __sync_val_compare_and_swap(&a->counter, old_v, new_v);
+}
+
+/* SPIN LOCKS */
+typedef struct {
+	pthread_spinlock_t lock;
+} env_spinlock;
+
+static inline void env_spinlock_init(env_spinlock *l)
+{
+	ENV_BUG_ON(pthread_spin_init(&l->lock, 0));
+}
+
+static inline void env_spinlock_lock(env_spinlock *l)
+{
+	ENV_BUG_ON(pthread_spin_lock(&l->lock));
+}
+
+static inline void env_spinlock_unlock(env_spinlock *l)
+{
+	ENV_BUG_ON(pthread_spin_unlock(&l->lock));
+}
+
+#define env_spinlock_lock_irqsave(l, flags) \
+		(void)flags; \
+		env_spinlock_lock(l)
+
+#define env_spinlock_unlock_irqrestore(l, flags) \
+		(void)flags; \
+		env_spinlock_unlock(l)
+
+static inline void env_spinlock_destroy(env_spinlock *l)
+{
+	ENV_BUG_ON(pthread_spin_destroy(&l->lock));
+}
+
+/* RW LOCKS */
+typedef struct {
+	pthread_rwlock_t lock;
+} env_rwlock;
+
+static inline void env_rwlock_init(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_init(&l->lock, NULL));
+}
+
+static inline void env_rwlock_read_lock(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_rdlock(&l->lock));
+}
+
+static inline void env_rwlock_read_unlock(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_unlock(&l->lock));
+}
+
+static inline void env_rwlock_write_lock(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_wrlock(&l->lock));
+}
+
+static inline void env_rwlock_write_unlock(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_unlock(&l->lock));
+}
+
+static inline void env_rwlock_destroy(env_rwlock *l)
+{
+	ENV_BUG_ON(pthread_rwlock_destroy(&l->lock));
+}
+
+/* BIT OPERATIONS */
+static inline void env_bit_set(int nr, volatile void *addr)
+{
+	char *byte = (char *)addr + (nr >> 3);
+	char mask = 1 << (nr & 7);
+
+	__sync_or_and_fetch(byte, mask);
+}
+
+static inline void env_bit_clear(int nr, volatile void *addr)
+{
+	char *byte = (char *)addr + (nr >> 3);
+	char mask = 1 << (nr & 7);
+
+	mask = ~mask;
+	__sync_and_and_fetch(byte, mask);
+}
+
+static inline bool env_bit_test(int nr, const volatile unsigned long *addr)
+{
+	const char *byte = (char *)addr + (nr >> 3);
+	char mask = 1 << (nr & 7);
+
+	return !!(*byte & mask);
+}
+
+/* SCHEDULING */
+static inline int env_in_interrupt(void)
+{
+	return 0;
+}
+
+static inline uint64_t env_get_tick_count(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return tv.tv_sec * 1000000 + tv.tv_usec;
+}
+
+static inline uint64_t env_ticks_to_nsecs(uint64_t j)
+{
+	return j * 1000;
+}
+
+static inline uint64_t env_ticks_to_msecs(uint64_t j)
+{
+	return j / 1000;
+}
+
+static inline uint64_t env_ticks_to_secs(uint64_t j)
+{
+	return j / 1000000;
+}
+
+static inline uint64_t env_secs_to_ticks(uint64_t j)
+{
+	return j * 1000000;
+}
+
+/* SORTING */
+static inline void env_sort(void *base, size_t num, size_t size,
+		int (*cmp_fn)(const void *, const void *),
+		void (*swap_fn)(void *, void *, int size))
+{
+	qsort(base, num, size, cmp_fn);
+}
+
+/* TIME */
+static inline void env_msleep(uint64_t n)
+{
+	usleep(n * 1000);
+}
+
+struct env_timeval {
+	uint64_t sec, usec;
+};
+
+#endif /* *** REGULAR FUNCTIONS' DECLARATIONS *** */
+
+
+/* *** UNIT TESTS' FUNCTIONS' DECLARATIONS *** */
+#ifdef TEST
+
+/* BUG ON FOR TESTING */
 void bug_on(int cond);
 
+/* MEMORY MANAGEMENT */
 void *env_malloc(size_t size, int flags);
 
 void *env_zalloc(size_t size, int flags);
@@ -106,20 +705,10 @@ void env_vfree(const void *ptr);
 
 uint64_t env_get_free_memory(void);
 
-/* *** ALLOCATOR *** */
-
-typedef struct _env_allocator env_allocator;
-
+/* ALLOCATOR */
 env_allocator *env_allocator_create(uint32_t size, const char *name);
 
-void env_allocator_destroy(env_allocator *allocator);
-
-void *env_allocator_new(env_allocator *allocator);
-
-void env_allocator_del(env_allocator *allocator, void *item);
-
-/* *** MUTEX *** */
-
+/* MUTEX */
 typedef struct {
 	pthread_mutex_t m;
 } env_mutex;
@@ -132,8 +721,7 @@ int env_mutex_lock_interruptible(env_mutex *mutex);
 
 void env_mutex_unlock(env_mutex *mutex);
 
-/* *** RECURSIVE MUTEX *** */
-
+/* RECURSIVE MUTEX */
 typedef env_mutex env_rmutex;
 
 int env_rmutex_init(env_rmutex *rmutex);
@@ -144,7 +732,7 @@ int env_rmutex_lock_interruptible(env_rmutex *rmutex);
 
 void env_rmutex_unlock(env_rmutex *rmutex);
 
-/* *** RW SEMAPHORE *** */
+/* RW SEMAPHORE */
 typedef struct {
 	pthread_rwlock_t lock;
 } env_rwsem;
@@ -163,10 +751,8 @@ void env_rwsem_down_write(env_rwsem *s);
 
 int env_rwsem_down_write_trylock(env_rwsem *s);
 
-/* *** ATOMIC VARIABLES *** */
-
+/* ATOMIC VARIABLES */
 typedef int env_atomic;
-
 typedef long env_atomic64;
 
 int env_atomic_read(const env_atomic *a);
@@ -209,9 +795,9 @@ void env_atomic64_dec(env_atomic64 *a);
 
 long env_atomic64_cmpxchg(env_atomic64 *a, long old, long new);
 
+/* COMPLETION */
 typedef int Coroutine;
 
-/* *** COMPLETION *** */
 struct completion {
 	bool completed;
 	bool waiting;
@@ -224,8 +810,7 @@ void env_completion_init(env_completion *completion);
 void env_completion_wait(env_completion *completion);
 void env_completion_complete(env_completion *completion);
 
-/* *** SPIN LOCKS *** */
-
+/* SPIN LOCKS */
 typedef struct {
 } env_spinlock;
 
@@ -241,8 +826,7 @@ void env_spinlock_unlock(env_spinlock *l);
 #define env_spinlock_unlock_irqrestore(l, flags) \
 	env_spinlock_unlock(l); (void)flags;
 
-/* *** RW LOCKS *** */
-
+/* RW LOCKS */
 typedef struct {
 } env_rwlock;
 
@@ -256,50 +840,7 @@ void env_rwlock_write_lock(env_rwlock *l);
 
 void env_rwlock_write_unlock(env_rwlock *l);
 
-/* *** WAITQUEUE *** */
-
-typedef struct {
-	bool waiting;
-	bool completed;
-	Coroutine *co;
-} env_waitqueue;
-
-#define env_waitqueue_wait(w, condition)	\
-({						\
-	int __ret = 0;				\
-	if (!(condition) && !w.completed) {	\
-		w.waiting = true;		\
-	}					\
-	w.co = NULL;				\
-	w.waiting = false;			\
-	w.completed = false;			\
-	__ret = __ret;				\
-})
-
-/* *** BIT OPERATIONS *** */
-
-void env_bit_set(int nr, volatile void *addr);
-
-void env_bit_clear(int nr, volatile void *addr);
-
-bool env_bit_test(int nr, const volatile unsigned long *addr);
-
-/* *** SCHEDULING *** */
-
-void env_touch_softlockup_wd(void);
-
-int env_in_interrupt(void);
-
-uint64_t env_get_tick_count(void);
-
-uint64_t env_ticks_to_msecs(uint64_t j);
-
-uint64_t env_ticks_to_secs(uint64_t j);
-
-uint64_t env_secs_to_ticks(uint64_t j);
-
-/* *** STRING OPERATIONS *** */
-
+/* STRING OPERATIONS */
 int env_memset(void *dest, size_t count, int ch);
 
 int env_memcpy(void *dest, size_t destsz, const void * src, size_t count);
@@ -313,16 +854,28 @@ size_t env_strnlen(const char *str, size_t strsz);
 
 int env_strncmp(const char * str1, const char * str2, size_t num);
 
-/* *** SORTING *** */
+/* SCHEDULING */
+void env_touch_softlockup_wd(void);
 
+int env_in_interrupt(void);
+
+uint64_t env_get_tick_count(void);
+
+uint64_t env_ticks_to_msecs(uint64_t j);
+
+uint64_t env_ticks_to_secs(uint64_t j);
+
+uint64_t env_secs_to_ticks(uint64_t j);
+
+/* SORTING */
 void env_sort(void *base, size_t num, size_t size,
 		int (*cmp_fn)(const void *, const void *),
 		void (*swap_fn)(void *, void *, int size));
 
+/* TIME */
 void env_msleep(uint64_t n);
 
-/* *** CRC *** */
+#endif	/* *** UNIT TESTS' FUNCTIONS' DECLARATIONS *** */
 
-uint32_t env_crc32(uint32_t crc, uint8_t const *data, size_t len);
-
-#endif /* __OCF_ENV_H__ */
+#endif	/* __LIBOCF_ENV_H__ */
+#endif	/* __OCF_ENV_H__ */

--- a/tests/unit/tests/ocf_env/ocf_env_headers.h
+++ b/tests/unit/tests/ocf_env/ocf_env_headers.h
@@ -1,13 +1,28 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
+/**
+ * @file
+ * @brief OCF libs and macros
+ *
+* This file is mostly to aggregate external header includes.
+ */
 #ifndef __OCF_ENV_HEADERS_H__
 #define __OCF_ENV_HEADERS_H__
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <stddef.h>
+#include <stdbool.h>
+
+/* TODO: Move prefix printing to context logger. */
+#define OCF_LOGO ""
+#define OCF_PREFIX_SHORT "[" OCF_LOGO "] "
+#define OCF_PREFIX_LONG "Open CAS Framework"
+
+#define OCF_VERSION_MAIN 1
+#define OCF_VERSION_MAJOR 1
+#define OCF_VERSION_MINOR 1
 
 #endif /* __OCF_ENV_HEADERS_H__ */

--- a/tests/unit/tests/ocf_env/ocf_env_list.h
+++ b/tests/unit/tests/ocf_env/ocf_env_list.h
@@ -1,10 +1,16 @@
 /*
- * Copyright(c) 2012-2018 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
-#ifndef __OCF_LIST_H__
-#define __OCF_LIST_H__
+/**
+ * @file
+ * @brief OCF lists
+ *
+ * Header file for OCF which contains customized list types.
+ */
+#ifndef __OCF_ENV_LIST__
+#define __OCF_ENV_LIST__
 
 #define LIST_POISON1  ((void *)0x101)
 #define LIST_POISON2  ((void *)0x202)
@@ -67,6 +73,28 @@ static inline void list_del(struct list_head *it)
 {
 	it->next->prev = it->prev;
 	it->prev->next = it->next;
+}
+
+/**
+ * Move element to list head.
+ * @param it list entry to be moved
+ * @param l1 list main node (head)
+ */
+static inline void list_move(struct list_head *it, struct list_head *l1)
+{
+	list_del(it);
+	list_add(it, l1);
+}
+
+/**
+ * Move element to list tail.
+ * @param it list entry to be moved
+ * @param l1 list main node (head)
+ */
+static inline void list_move_tail(struct list_head *it, struct list_head *l1)
+{
+	list_del(it);
+	list_add_tail(it, l1);
 }
 
 /**
@@ -143,4 +171,4 @@ static inline void list_del(struct list_head *it)
 		     _list_entry_helper(item, (plist)->next, field_name); \
 	     item = q, q = _list_entry_helper(q, (q)->field_name.next, field_name))
 
-#endif
+#endif /* __OCF_ENV_LIST__ */

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_dec.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_dec.c
@@ -20,7 +20,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_dec_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_dec_generated_wraps.c"
 
 static void ocf_refcnt_dec_test01(void **state)
 {

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_freeze.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_freeze.c
@@ -21,7 +21,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_freeze_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_freeze_generated_wraps.c"
 
 static void ocf_refcnt_freeze_test01(void **state)
 {

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_inc.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_inc.c
@@ -20,7 +20,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_inc_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_inc_generated_wraps.c"
 
 static void ocf_refcnt_inc_test(void **state)
 {

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_init.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_init.c
@@ -20,7 +20,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_init_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_init_generated_wraps.c"
 
 static void ocf_refcnt_init_test(void **state)
 {

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_register_zero_cb.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_register_zero_cb.c
@@ -22,7 +22,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_register_zero_cb_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_register_zero_cb_generated_wraps.c"
 
 static void zero_cb(void *ctx)
 {

--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_unfreeze.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_unfreeze.c
@@ -22,7 +22,7 @@
 
 #include "../utils/utils_refcnt.h"
 
-#include "utils/utils_refcnt.c/utils_refcnt_unfreeze_generated_warps.c"
+#include "utils/utils_refcnt.c/utils_refcnt_unfreeze_generated_wraps.c"
 
 static void ocf_refcnt_unfreeze_test01(void **state)
 {


### PR DESCRIPTION
**doc/**: Added config file and main page's draft for doxygen to document ocf_env.
**env/posix/**: Modify files to prepare ocf_env for documentation in doxygen generator, but this is really early phase. Also done some more cleanup with redundant includes.
**add_new_test_file.py**: Added parentheses in 'print' command.
**ocf**: Unused macros cleanup and use of unused but defined macro '__packed'.

Signed-off-by: Slawomir_Jankowski <slawomir.jankowski@intel.com>