### PR TITLE
Move parts metadata to separate section

### DIFF
--- a/src/metadata/metadata_hash.h
+++ b/src/metadata/metadata_hash.h
@@ -19,6 +19,8 @@ enum ocf_metadata_segment {
 	metadata_segment_sb_config = 0,	/*!< Super block conf */
 	metadata_segment_sb_runtime,	/*!< Super block runtime */
 	metadata_segment_reserved,	/*!< Reserved space on disk */
+	metadata_segment_part_config,	/*!< Part Config Metadata */
+	metadata_segment_part_runtime,	/*!< Part Runtime Metadata */
 	metadata_segment_core_config,	/*!< Core Config Metadata */
 	metadata_segment_core_runtime,	/*!< Core Runtime Metadata */
 	metadata_segment_core_uuid,	/*!< Core UUID */

--- a/src/metadata/metadata_superblock.h
+++ b/src/metadata/metadata_superblock.h
@@ -48,8 +48,6 @@ struct ocf_superblock_config {
 	/* Current core sequence number */
 	ocf_core_id_t curr_core_seq_no;
 
-	struct ocf_user_part_config user_parts[OCF_IO_CLASS_MAX + 1];
-
 	/*
 	 * Checksum for each metadata region.
 	 * This field has to be the last one!
@@ -62,8 +60,6 @@ struct ocf_superblock_config {
  */
 struct ocf_superblock_runtime {
 	struct ocf_part freelist_part;
-
-	struct ocf_user_part_runtime user_parts[OCF_IO_CLASS_MAX + 1];
 
 	uint32_t cleaning_thread_access;
 };

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -958,7 +958,7 @@ static void _ocf_mngt_attach_prepare_metadata(ocf_pipeline_t pipeline,
 {
 	struct ocf_cache_attach_context *context = priv;
 	ocf_cache_t cache = context->cache;
-	int ret, i;
+	int ret;
 
 	if (context->init_mode == ocf_init_mode_load &&
 			context->metadata.status) {
@@ -985,11 +985,6 @@ static void _ocf_mngt_attach_prepare_metadata(ocf_pipeline_t pipeline,
 		OCF_PL_FINISH_RET(context->pipeline, -OCF_ERR_START_CACHE_FAIL);
 	}
 
-
-	for (i = 0; i < OCF_IO_CLASS_MAX + 1; ++i) {
-		cache->user_parts[i].runtime =
-				&cache->device->runtime_meta->user_parts[i];
-	}
 
 	cache->device->freelist_part = &cache->device->runtime_meta->freelist_part;
 
@@ -1158,8 +1153,6 @@ static void _ocf_mngt_attach_handle_error(
 static void _ocf_mngt_cache_init(ocf_cache_t cache,
 		struct ocf_cache_mngt_init_params *params)
 {
-	int i;
-
 	/*
 	 * Super block elements initialization
 	 */
@@ -1167,11 +1160,6 @@ static void _ocf_mngt_cache_init(ocf_cache_t cache,
 	cache->conf_meta->metadata_layout = params->metadata.layout;
 	cache->conf_meta->promotion_policy_type =
 			params->metadata.promotion_policy;
-
-	for (i = 0; i < OCF_IO_CLASS_MAX + 1; ++i) {
-		cache->user_parts[i].config =
-				&cache->conf_meta->user_parts[i];
-	}
 
 	INIT_LIST_HEAD(&cache->io_queues);
 


### PR DESCRIPTION
Fix problem introduced by increasing partition name size to 1024 bytes,
which effectively made superblock bigger than one page. Due to this
flushing superblock required more than one io, which in case of dirty
shutdown between these ios resulted in CRC missmatch and made cache
recovery impossible.

Moving parts metadata to separate sections makes superblock fitting
in one page, effectively solving described problem.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>