### PR TITLE
Update OCF README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ utility.
 
 ## Documentation
 
-OCF documentation is available on [GitHub Pages](http://open-cas.github.io/doxygen/ocf).
+OCF documentation is available on [GitHub Pages](https://open-cas.github.io/getting_started_ocf.html).
 Doxygen API documentation is available [here](http://open-cas.github.io/doxygen/ocf).  
 
 ## Source Code


### PR DESCRIPTION
The doxygen API documentation link was being referenced twice. The first link should have pointed to https://open-cas.github.io/getting_started_ocf.html instead.