### PR TITLE
Fix stats update in cleaner.

### DIFF
--- a/src/utils/utils_cleaner.c
+++ b/src/utils/utils_cleaner.c
@@ -616,11 +616,12 @@ static void _ocf_cleaner_cache_io_cmpl(struct ocf_io *io, int error)
 {
 	struct ocf_map_info *map = io->priv1;
 	struct ocf_request *req = io->priv2;
+	ocf_core_t core = ocf_cache_get_core(req->cache, map->core_id);
 
 	if (error) {
 		map->invalid |= 1;
 		_ocf_cleaner_set_error(req);
-		ocf_core_stats_cache_error_update(req->core, OCF_READ);
+		ocf_core_stats_cache_error_update(core, OCF_READ);
 	}
 
 	_ocf_cleaner_cache_io_end(req);


### PR DESCRIPTION
Core is not assigned to request in cleaner, so to increase it's stats it has to
be retrieved from mapping.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>