### PR TITLE
Move cache name from sb_config to ocf_cache struct

### DIFF
--- a/src/metadata/metadata_superblock.h
+++ b/src/metadata/metadata_superblock.h
@@ -27,8 +27,6 @@ struct ocf_superblock_config {
 	/* Currently set cache mode */
 	ocf_cache_mode_t cache_mode;
 
-	char name[OCF_CACHE_NAME_SIZE];
-
 	ocf_cache_line_t cachelines;
 	uint32_t valid_parts_no;
 

--- a/src/ocf_cache.c
+++ b/src/ocf_cache.c
@@ -21,14 +21,14 @@ ocf_volume_t ocf_cache_get_volume(ocf_cache_t cache)
 int ocf_cache_set_name(ocf_cache_t cache, const char *src, size_t src_size)
 {
 	OCF_CHECK_NULL(cache);
-	return env_strncpy(cache->conf_meta->name, OCF_CACHE_NAME_SIZE,
+	return env_strncpy(cache->name, OCF_CACHE_NAME_SIZE,
 			src, src_size);
 }
 
 const char *ocf_cache_get_name(ocf_cache_t cache)
 {
 	OCF_CHECK_NULL(cache);
-	return cache->conf_meta->name;
+	return cache->name;
 }
 
 bool ocf_cache_is_incomplete(ocf_cache_t cache)

--- a/src/ocf_cache_priv.h
+++ b/src/ocf_cache_priv.h
@@ -100,6 +100,8 @@ struct ocf_cache {
 	/* unset running to not serve any more I/O requests */
 	unsigned long cache_state;
 
+	char name[OCF_CACHE_NAME_SIZE];
+
 	struct ocf_superblock_config *conf_meta;
 
 	struct ocf_cache_device *device;


### PR DESCRIPTION
When loading metadata, ocf used to overwrite cache name supplied by adapter with
loaded name without any check if that name was already used by another cache
instance. As a result two cache instances with identical name could be running.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>