### PR TITLE
Fix pp tests

### DIFF
--- a/src/promotion/nhit/nhit.c
+++ b/src/promotion/nhit/nhit.c
@@ -185,7 +185,7 @@ bool nhit_req_should_promote(ocf_promotion_policy_t policy,
 	uint32_t i;
 	uint64_t core_line;
 	uint64_t occupied_cachelines =
-		ocf_metadata_get_cachelines_count(policy->owner) -
+		ocf_metadata_collision_table_entries(policy->owner) -
 		ocf_freelist_num_free(policy->owner->freelist);
 
 	if (occupied_cachelines < env_atomic64_read(&ctx->trigger_threshold))

--- a/tests/functional/tests/engine/test_pp.py
+++ b/tests/functional/tests/engine/test_pp.py
@@ -179,9 +179,8 @@ def fill_cache(cache, fill_ratio):
 
 @pytest.mark.parametrize("fill_percentage", [0, 1, 50, 99])
 @pytest.mark.parametrize("insertion_threshold", [2, 8])
-@pytest.mark.parametrize("io_dir", IoDir)
 def test_promoted_after_hits_various_thresholds(
-    pyocf_ctx, io_dir, insertion_threshold, fill_percentage
+    pyocf_ctx, insertion_threshold, fill_percentage
 ):
     """
     Check promotion policy behavior with various set thresholds
@@ -230,7 +229,7 @@ def test_promoted_after_hits_various_thresholds(
             cache.get_default_queue(),
             last_core_line,
             write_data.size,
-            io_dir,
+            IoDir.WRITE,
             0,
             0,
         )
@@ -253,13 +252,13 @@ def test_promoted_after_hits_various_thresholds(
     comp = OcfCompletion([("error", c_int)])
     write_data = Data(cache_lines.line_size)
     io = core.new_io(
-        cache.get_default_queue(), last_core_line, write_data.size, io_dir, 0, 0
+        cache.get_default_queue(), last_core_line, write_data.size, IoDir.WRITE, 0, 0
     )
     io.set_data(write_data)
     io.callback = comp.callback
     io.submit()
 
-    c.wait()
+    comp.wait()
 
     assert (
         threshold_reached_occupancy


### PR DESCRIPTION
- Minor cosmetic fix in `nhit.c` to make occupancy calculation across codebase similar
- Removed testing across different IO directions - READ would be problematic because of backfill - waiting for IO end would be insufficient
- Fixed test waiting for wrong completion and sometimes failing randomly