### PR TITLE
Handle loading cache with existing name.

### DIFF
--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -290,6 +290,7 @@ static void ocf_metadata_load_properties_cmpl(
 	properties.cache_mode = superblock->cache_mode;
 	properties.shutdown_status = superblock->clean_shutdown;
 	properties.dirty_flushed = superblock->dirty_flushed;
+	properties.cache_name = superblock->name;
 
 	OCF_CMPL_RET(priv, 0, &properties);
 }

--- a/src/metadata/metadata.h
+++ b/src/metadata/metadata.h
@@ -206,6 +206,7 @@ struct ocf_metadata_load_properties {
 	ocf_metadata_layout_t layout;
 	ocf_cache_line_size_t line_size;
 	ocf_cache_mode_t cache_mode;
+	char *cache_name;
 };
 
 typedef void (*ocf_metadata_load_properties_end_t)(void *priv, int error,


### PR DESCRIPTION
When loading cache metadata from disk, name provided by adapter is overrided by
name loaded from metadata. No check was performed to ensure that name loaded
name isn't already occupied, so there was a possibility that two caches with
the same name were running simultaneously.

This patch is extending loading cache properties with check for existing cache
with loaded name.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>