### PR TITLE
ocf_async_lock: Replace mutex with spinlocks

### DIFF
--- a/src/utils/utils_async_lock.h
+++ b/src/utils/utils_async_lock.h
@@ -10,7 +10,7 @@
 
 struct ocf_async_lock {
 	struct list_head waiters;
-	env_mutex mutex;
+	env_spinlock waiters_lock;
 	uint32_t rd;
 	uint32_t wr;
 	uint32_t waiter_priv_size;


### PR DESCRIPTION
The ocf_async_lock may be used in atomic context, thus we need
to replace synchronization primitives to non-sleeping variants.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>