### PR TITLE
Store PP config params in cache superblock.

### DIFF
--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -814,26 +814,28 @@ ocf_promotion_t ocf_mngt_cache_promotion_get_policy(ocf_cache_t cache);
  *
  * @param[in] cache Cache handle
  * @param[in] param_id Promotion policy parameter id
+ * @param[in] type Promotion policy type
  * @param[in] param_value Promotion policy parameter value
  *
  * @retval 0 Parameter has been set successfully
  * @retval Non-zero Error occurred and parameter has not been set
  */
 int ocf_mngt_cache_promotion_set_param(ocf_cache_t cache, uint8_t param_id,
-		uint32_t param_value);
+		ocf_promotion_t type, uint32_t param_value);
 
 /**
  * @brief Get promotion policy parameter for given cache
  *
  * @param[in] cache Cache handle
  * @param[in] param_id Promotion policy parameter id
+ * @param[in] type Promotion policy type
  * @param[out] param_value Variable to store parameter value
  *
  * @retval 0 Parameter has been retrieved successfully
  * @retval Non-zero Error occurred and parameter has not been retrieved
  */
 int ocf_mngt_cache_promotion_get_param(ocf_cache_t cache, uint8_t param_id,
-		uint32_t *param_value);
+		ocf_promotion_t type, uint32_t *param_value);
 
 /**
  * @brief IO class configuration

--- a/src/metadata/metadata_superblock.h
+++ b/src/metadata/metadata_superblock.h
@@ -42,8 +42,10 @@ struct ocf_superblock_config {
 	ocf_cleaning_t cleaning_policy_type;
 	struct cleaning_policy_config cleaning[CLEANING_POLICY_TYPE_MAX];
 
-	ocf_eviction_t eviction_policy_type;
 	ocf_promotion_t promotion_policy_type;
+	struct promotion_policy_config promotion[PROMOTION_POLICY_TYPE_MAX];
+
+	ocf_eviction_t eviction_policy_type;
 
 	/* Current core sequence number */
 	ocf_core_id_t curr_core_seq_no;

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2276,14 +2276,13 @@ ocf_promotion_t ocf_mngt_cache_promotion_get_policy(ocf_cache_t cache)
 }
 
 int ocf_mngt_cache_promotion_get_param(ocf_cache_t cache, uint8_t param_id,
-		uint32_t *param_value)
+		ocf_promotion_t type, uint32_t *param_value)
 {
 	int result;
 
 	ocf_metadata_start_shared_access(&cache->metadata.lock);
 
-	result = ocf_promotion_get_param(cache->promotion_policy, param_id,
-			param_value);
+	result = ocf_promotion_get_param(cache, param_id, type, param_value);
 
 	ocf_metadata_end_shared_access(&cache->metadata.lock);
 
@@ -2291,16 +2290,15 @@ int ocf_mngt_cache_promotion_get_param(ocf_cache_t cache, uint8_t param_id,
 }
 
 int ocf_mngt_cache_promotion_set_param(ocf_cache_t cache, uint8_t param_id,
-		uint32_t param_value)
+		ocf_promotion_t type, uint32_t param_value)
 {
 	int result;
 
-	ocf_metadata_start_shared_access(&cache->metadata.lock);
+	ocf_metadata_start_exclusive_access(&cache->metadata.lock);
 
-	result = ocf_promotion_set_param(cache->promotion_policy, param_id,
-			param_value);
+	result = ocf_promotion_set_param(cache, param_id, type, param_value);
 
-	ocf_metadata_end_shared_access(&cache->metadata.lock);
+	ocf_metadata_end_exclusive_access(&cache->metadata.lock);
 
 	return result;
 }

--- a/src/promotion/nhit/nhit.c
+++ b/src/promotion/nhit/nhit.c
@@ -15,16 +15,15 @@
 
 struct nhit_policy_context {
 	nhit_hash_t hash_map;
-
-	/* Configurable parameters */
-	env_atomic insertion_threshold;
-	env_atomic trigger_threshold;
 };
 
 ocf_error_t nhit_init(ocf_cache_t cache, ocf_promotion_policy_t policy)
 {
 	struct nhit_policy_context *ctx;
+	struct nhit_promotion_policy_config *cfg;
 	int result = 0;
+
+	cfg = (void *) &cache->conf_meta->promotion[ocf_promotion_nhit].data;
 
 	ctx = env_vmalloc(sizeof(*ctx));
 	if (!ctx) {
@@ -37,8 +36,8 @@ ocf_error_t nhit_init(ocf_cache_t cache, ocf_promotion_policy_t policy)
 	if (result)
 		goto dealloc_ctx;
 
-	env_atomic_set(&ctx->insertion_threshold, OCF_NHIT_THRESHOLD_DEFAULT);
-	env_atomic_set(&ctx->trigger_threshold, OCF_NHIT_TRIGGER_DEFAULT);
+	cfg->insertion_threshold = OCF_NHIT_THRESHOLD_DEFAULT;
+	cfg->trigger_threshold = OCF_NHIT_TRIGGER_DEFAULT;
 	policy->ctx = ctx;
 
 	return 0;
@@ -60,22 +59,24 @@ void nhit_deinit(ocf_promotion_policy_t policy)
 	policy->ctx = NULL;
 }
 
-ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
+ocf_error_t nhit_set_param(ocf_cache_t cache, uint8_t param_id,
 		uint32_t param_value)
 {
-	struct nhit_policy_context *ctx = policy->ctx;
+	struct nhit_promotion_policy_config *cfg;
 	ocf_error_t result = 0;
+
+	cfg = (void *) &cache->conf_meta->promotion[ocf_promotion_nhit].data;
 
 	switch (param_id) {
 	case ocf_nhit_insertion_threshold:
 		if (param_value >= OCF_NHIT_MIN_THRESHOLD &&
 				param_value <= OCF_NHIT_MAX_THRESHOLD) {
-			env_atomic_set(&ctx->insertion_threshold, param_value);
-			ocf_cache_log(policy->owner, log_info,
+			cfg->insertion_threshold = param_value;
+			ocf_cache_log(cache, log_info,
 					"Nhit PP insertion threshold value set to %u",
 					param_value);
 		} else {
-			ocf_cache_log(policy->owner, log_err, "Invalid nhit "
+			ocf_cache_log(cache, log_err, "Invalid nhit "
 					"promotion policy insertion threshold!\n");
 			result = -OCF_ERR_INVAL;
 		}
@@ -84,12 +85,12 @@ ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
 	case ocf_nhit_trigger_threshold:
 		if (param_value >= OCF_NHIT_MIN_TRIGGER &&
 				param_value <= OCF_NHIT_MAX_TRIGGER) {
-			env_atomic_set(&ctx->trigger_threshold, param_value);
-			ocf_cache_log(policy->owner, log_info,
+			cfg->trigger_threshold = param_value;
+			ocf_cache_log(cache, log_info,
 					"Nhit PP trigger threshold value set to %u%%\n",
 					param_value);
 		} else {
-			ocf_cache_log(policy->owner, log_err, "Invalid nhit "
+			ocf_cache_log(cache, log_err, "Invalid nhit "
 					"promotion policy insertion trigger "
 					"threshold!\n");
 			result = -OCF_ERR_INVAL;
@@ -97,7 +98,7 @@ ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
 		break;
 
 	default:
-		ocf_cache_log(policy->owner, log_err, "Invalid nhit "
+		ocf_cache_log(cache, log_err, "Invalid nhit "
 				"promotion policy parameter (%u)!\n",
 				param_id);
 		result = -OCF_ERR_INVAL;
@@ -108,23 +109,25 @@ ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
 	return result;
 }
 
-ocf_error_t nhit_get_param(ocf_promotion_policy_t policy, uint8_t param_id,
+ocf_error_t nhit_get_param(ocf_cache_t cache, uint8_t param_id,
 		uint32_t *param_value)
 {
-	struct nhit_policy_context *ctx = policy->ctx;
+	struct nhit_promotion_policy_config *cfg;
 	ocf_error_t result = 0;
+
+	cfg = (void *) &cache->conf_meta->promotion[ocf_promotion_nhit].data;
 
 	OCF_CHECK_NULL(param_value);
 
 	switch (param_id) {
 	case ocf_nhit_insertion_threshold:
-		*param_value = env_atomic_read(&ctx->insertion_threshold);
+		*param_value = cfg->insertion_threshold;
 		break;
 	case ocf_nhit_trigger_threshold:
-		*param_value = env_atomic_read(&ctx->trigger_threshold);
+		*param_value = cfg->trigger_threshold;
 		break;
 	default:
-		ocf_cache_log(policy->owner, log_err, "Invalid nhit "
+		ocf_cache_log(cache, log_err, "Invalid nhit "
 				"promotion policy parameter (%u)!\n",
 				param_id);
 		result = -OCF_ERR_INVAL;
@@ -156,16 +159,21 @@ void nhit_req_purge(ocf_promotion_policy_t policy,
 	}
 }
 
-static bool core_line_should_promote(struct nhit_policy_context *ctx,
+static bool core_line_should_promote(ocf_promotion_policy_t policy,
 		ocf_core_id_t core_id, uint64_t core_lba)
 {
+	struct nhit_promotion_policy_config *cfg;
+	struct nhit_policy_context *ctx;
 	bool hit;
 	int32_t counter;
+
+	cfg = (void *)&policy->owner->conf_meta->promotion[ocf_promotion_nhit].data;
+	ctx = policy->ctx;
 
 	hit = nhit_hash_query(ctx->hash_map, core_id, core_lba, &counter);
 	if (hit) {
 		/* we have a hit, return now */
-		return env_atomic_read(&ctx->insertion_threshold) <= counter;
+		return cfg->insertion_threshold <= counter;
 	}
 
 	nhit_hash_insert(ctx->hash_map, core_id, core_lba);
@@ -176,7 +184,7 @@ static bool core_line_should_promote(struct nhit_policy_context *ctx,
 bool nhit_req_should_promote(ocf_promotion_policy_t policy,
 		struct ocf_request *req)
 {
-	struct nhit_policy_context *ctx = policy->ctx;
+	struct nhit_promotion_policy_config *cfg;
 	bool result = true;
 	uint32_t i;
 	uint64_t core_line;
@@ -184,8 +192,10 @@ bool nhit_req_should_promote(ocf_promotion_policy_t policy,
 		ocf_metadata_collision_table_entries(policy->owner) -
 		ocf_freelist_num_free(policy->owner->freelist);
 
+	cfg = (void *)&policy->owner->conf_meta->promotion[ocf_promotion_nhit].data;
+
 	if (occupied_cachelines < OCF_DIV_ROUND_UP(
-			((uint64_t) env_atomic_read(&ctx->trigger_threshold) *
+			((uint64_t)cfg->trigger_threshold *
 			ocf_metadata_get_cachelines_count(policy->owner)), 100))
 		return true;
 
@@ -193,7 +203,7 @@ bool nhit_req_should_promote(ocf_promotion_policy_t policy,
 			core_line <= req->core_line_last; core_line++, i++) {
 		struct ocf_map_info *entry = &(req->map[i]);
 
-		if (!core_line_should_promote(ctx, entry->core_id,
+		if (!core_line_should_promote(policy, entry->core_id,
 					entry->core_line)) {
 			result = false;
 		}

--- a/src/promotion/nhit/nhit.h
+++ b/src/promotion/nhit/nhit.h
@@ -9,15 +9,16 @@
 #include "ocf/ocf.h"
 #include "../../ocf_request.h"
 #include "../promotion.h"
+#include "nhit_structs.h"
 
 ocf_error_t nhit_init(ocf_cache_t cache, ocf_promotion_policy_t policy);
 
 void nhit_deinit(ocf_promotion_policy_t policy);
 
-ocf_error_t nhit_set_param(ocf_promotion_policy_t policy, uint8_t param_id,
+ocf_error_t nhit_set_param(ocf_cache_t cache, uint8_t param_id,
 		uint32_t param_value);
 
-ocf_error_t nhit_get_param(ocf_promotion_policy_t policy, uint8_t param_id,
+ocf_error_t nhit_get_param(ocf_cache_t cache, uint8_t param_id,
 		uint32_t *param_value);
 
 void nhit_req_purge(ocf_promotion_policy_t policy,

--- a/src/promotion/nhit/nhit_structs.h
+++ b/src/promotion/nhit/nhit_structs.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright(c) 2012-2019 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+#ifndef __PROMOTION_NHIT_STRUCTS_H_
+#define __PROMOTION_NHIT_STRUCTS_H_
+
+struct nhit_promotion_policy_config {
+	uint32_t insertion_threshold;
+	/*!< Number of hits */
+
+	uint32_t trigger_threshold;
+	/*!< Cache occupancy (percentage value) */
+};
+
+#endif

--- a/src/promotion/ops.h
+++ b/src/promotion/ops.h
@@ -26,11 +26,11 @@ struct promotion_policy_ops {
 	void (*deinit)(ocf_promotion_policy_t policy);
 		/*!< Deinit and free promotion policy */
 
-	ocf_error_t (*set_param)(ocf_promotion_policy_t policy, uint8_t param_id,
+	ocf_error_t (*set_param)(ocf_cache_t cache, uint8_t param_id,
 			uint32_t param_value);
 		/*!< Set promotion policy parameter */
 
-	ocf_error_t (*get_param)(ocf_promotion_policy_t policy, uint8_t param_id,
+	ocf_error_t (*get_param)(ocf_cache_t cache, uint8_t param_id,
 			uint32_t *param_value);
 		/*!< Get promotion policy parameter */
 

--- a/src/promotion/promotion.c
+++ b/src/promotion/promotion.c
@@ -95,32 +95,30 @@ ocf_error_t ocf_promotion_set_policy(ocf_promotion_policy_t policy,
 	return result;
 }
 
-ocf_error_t ocf_promotion_set_param(ocf_promotion_policy_t policy,
-		uint8_t param_id, uint32_t param_value)
+ocf_error_t ocf_promotion_set_param(ocf_cache_t cache, uint8_t param_id,
+		ocf_promotion_t type, uint32_t param_value)
 {
-	ocf_promotion_t type = policy->type;
 	ocf_error_t result = -OCF_ERR_INVAL;
 
 	ENV_BUG_ON(type >= ocf_promotion_max);
 
 	if (ocf_promotion_policies[type].set_param) {
-		result = ocf_promotion_policies[type].set_param(policy, param_id,
+		result = ocf_promotion_policies[type].set_param(cache, param_id,
 				param_value);
 	}
 
 	return result;
 }
 
-ocf_error_t ocf_promotion_get_param(ocf_promotion_policy_t policy,
-		uint8_t param_id, uint32_t *param_value)
+ocf_error_t ocf_promotion_get_param(ocf_cache_t cache, uint8_t param_id,
+		ocf_promotion_t type, uint32_t *param_value)
 {
-	ocf_promotion_t type = policy->type;
 	ocf_error_t result = -OCF_ERR_INVAL;
 
 	ENV_BUG_ON(type >= ocf_promotion_max);
 
 	if (ocf_promotion_policies[type].get_param) {
-		result = ocf_promotion_policies[type].get_param(policy, param_id,
+		result = ocf_promotion_policies[type].get_param(cache, param_id,
 				param_value);
 	}
 

--- a/src/promotion/promotion.h
+++ b/src/promotion/promotion.h
@@ -9,6 +9,13 @@
 #include "ocf/ocf.h"
 #include "../ocf_request.h"
 
+#define PROMOTION_POLICY_CONFIG_BYTES 256
+#define PROMOTION_POLICY_TYPE_MAX 2
+
+struct promotion_policy_config {
+	uint8_t data[PROMOTION_POLICY_CONFIG_BYTES];
+};
+
 typedef struct ocf_promotion_policy *ocf_promotion_policy_t;
 /**
  * @brief Allocate and initialize promotion policy. Should be called after cache
@@ -44,26 +51,28 @@ ocf_error_t ocf_promotion_set_policy(ocf_promotion_policy_t policy,
 /**
  * @brief Set promotion policy parameter
  *
- * @param[in] policy promotion policy handle
+ * @param[in] cache cache handle
  * @param[in] param_id id of parameter to be set
+ * @param[in] type id of propmotion policy to be configured
  * @param[in] param_value value of parameter to be set
  *
  * @retval ocf_error_t
  */
-ocf_error_t ocf_promotion_set_param(ocf_promotion_policy_t policy,
-		uint8_t param_id, uint32_t param_value);
+ocf_error_t ocf_promotion_set_param(ocf_cache_t cache, uint8_t param_id,
+		ocf_promotion_t type, uint32_t param_value);
 
 /**
  * @brief Get promotion policy parameter
  *
- * @param[in] policy promotion policy handle
+ * @param[in] cache cache handle
  * @param[in] param_id id of parameter to be set
+ * @param[in] type id of propmotion policy to be configured
  * @param[out] param_value value of parameter to be set
  *
  * @retval ocf_error_t
  */
-ocf_error_t ocf_promotion_get_param(ocf_promotion_policy_t policy,
-		uint8_t param_id, uint32_t *param_value);
+ocf_error_t ocf_promotion_get_param(ocf_cache_t cache, uint8_t param_id,
+		ocf_promotion_t type, uint32_t *param_value);
 
 /**
  * @brief Update promotion policy after cache lines have been promoted to cache

--- a/tests/functional/tests/engine/test_pp.py
+++ b/tests/functional/tests/engine/test_pp.py
@@ -7,11 +7,7 @@ from ctypes import c_int
 import pytest
 import math
 
-from pyocf.types.cache import (
-    Cache,
-    PromotionPolicy,
-    NhitParams,
-)
+from pyocf.types.cache import Cache, PromotionPolicy, NhitParams
 from pyocf.types.core import Core
 from pyocf.types.volume import Volume
 from pyocf.types.data import Data
@@ -71,12 +67,7 @@ def test_change_to_nhit_and_back_io_in_flight(pyocf_ctx):
         comp = OcfCompletion([("error", c_int)])
         write_data = Data(4096)
         io = core.new_io(
-            cache.get_default_queue(),
-            i * 4096,
-            write_data.size,
-            IoDir.WRITE,
-            0,
-            0,
+            cache.get_default_queue(), i * 4096, write_data.size, IoDir.WRITE, 0, 0
         )
         completions += [comp]
         io.set_data(write_data)
@@ -89,9 +80,7 @@ def test_change_to_nhit_and_back_io_in_flight(pyocf_ctx):
     # Step 4
     for c in completions:
         c.wait()
-        assert not c.results[
-            "error"
-        ], "No IO's should fail when turning NHIT policy on"
+        assert not c.results["error"], "No IO's should fail when turning NHIT policy on"
 
     # Step 5
     completions = []
@@ -99,12 +88,7 @@ def test_change_to_nhit_and_back_io_in_flight(pyocf_ctx):
         comp = OcfCompletion([("error", c_int)])
         write_data = Data(4096)
         io = core.new_io(
-            cache.get_default_queue(),
-            i * 4096,
-            write_data.size,
-            IoDir.WRITE,
-            0,
-            0,
+            cache.get_default_queue(), i * 4096, write_data.size, IoDir.WRITE, 0, 0
         )
         completions += [comp]
         io.set_data(write_data)
@@ -157,9 +141,7 @@ def fill_cache(cache, fill_ratio):
 
     if bytes_to_fill % max_io_size:
         comp = OcfCompletion([("error", c_int)])
-        write_data = Data(
-            Size.from_B(bytes_to_fill % max_io_size, sector_aligned=True)
-        )
+        write_data = Data(Size.from_B(bytes_to_fill % max_io_size, sector_aligned=True))
         io = core.new_io(
             cache.get_default_queue(),
             ios_to_issue * max_io_size,
@@ -198,18 +180,16 @@ def test_promoted_after_hits_various_thresholds(
     cache_device = Volume(Size.from_MiB(30))
     core_device = Volume(Size.from_MiB(30))
 
-    cache = Cache.start_on_device(
-        cache_device, promotion_policy=PromotionPolicy.NHIT
-    )
+    cache = Cache.start_on_device(cache_device, promotion_policy=PromotionPolicy.NHIT)
     core = Core.using_device(core_device)
     cache.add_core(core)
 
     # Step 2
     cache.set_promotion_policy_param(
-        NhitParams.TRIGGER_THRESHOLD, fill_percentage
+        NhitParams.TRIGGER_THRESHOLD, PromotionPolicy.NHIT, fill_percentage
     )
     cache.set_promotion_policy_param(
-        NhitParams.INSERTION_THRESHOLD, insertion_threshold
+        NhitParams.INSERTION_THRESHOLD, PromotionPolicy.NHIT, insertion_threshold
     )
     # Step 3
     fill_cache(cache, fill_percentage / 100)
@@ -290,9 +270,7 @@ def test_partial_hit_promotion(pyocf_ctx):
     # Step 2
     comp = OcfCompletion([("error", c_int)])
     write_data = Data(Size.from_sector(1))
-    io = core.new_io(
-        cache.get_default_queue(), 0, write_data.size, IoDir.READ, 0, 0
-    )
+    io = core.new_io(cache.get_default_queue(), 0, write_data.size, IoDir.READ, 0, 0)
     io.set_data(write_data)
     io.callback = comp.callback
     io.submit()
@@ -305,15 +283,17 @@ def test_partial_hit_promotion(pyocf_ctx):
 
     # Step 3
     cache.set_promotion_policy(PromotionPolicy.NHIT)
-    cache.set_promotion_policy_param(NhitParams.TRIGGER_THRESHOLD, 0)
-    cache.set_promotion_policy_param(NhitParams.INSERTION_THRESHOLD, 100)
+    cache.set_promotion_policy_param(
+        NhitParams.TRIGGER_THRESHOLD, PromotionPolicy.NHIT, 0
+    )
+    cache.set_promotion_policy_param(
+        NhitParams.INSERTION_THRESHOLD, PromotionPolicy.NHIT, 100
+    )
 
     # Step 4
     comp = OcfCompletion([("error", c_int)])
     write_data = Data(2 * cache_lines.line_size)
-    io = core.new_io(
-        cache.get_default_queue(), 0, write_data.size, IoDir.WRITE, 0, 0
-    )
+    io = core.new_io(cache.get_default_queue(), 0, write_data.size, IoDir.WRITE, 0, 0)
     io.set_data(write_data)
     io.callback = comp.callback
     io.submit()


### PR DESCRIPTION
It allows to modify and retrieve particular PP params event if it isn't active
and store values between cache stop and load.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>