### PR TITLE
Deinitialize locks on cache stop instead of put

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -1986,10 +1986,15 @@ static void ocf_mngt_cache_stop_put_io_queues(ocf_pipeline_t pipeline,
 
 static void ocf_mngt_cache_remove(ocf_ctx_t ctx, ocf_cache_t cache)
 {
-	env_rmutex_lock(&ctx->lock);
 	/* Mark device uninitialized */
 	ocf_refcnt_freeze(&cache->refcnt.cache);
+
+	/* Deinitialize locks */
+	ocf_mngt_cache_lock_deinit(cache);
+	env_mutex_destroy(&cache->flush_mutex);
+
 	/* Remove cache from the list */
+	env_rmutex_lock(&ctx->lock);
 	list_del(&cache->list);
 	env_rmutex_unlock(&ctx->lock);
 }

--- a/src/mngt/ocf_mngt_common.c
+++ b/src/mngt/ocf_mngt_common.c
@@ -135,8 +135,6 @@ void ocf_mngt_cache_put(ocf_cache_t cache)
 	if (ocf_refcnt_dec(&cache->refcnt.cache) == 0) {
 		ctx = cache->owner;
 		ocf_metadata_deinit(cache);
-		ocf_mngt_cache_lock_deinit(cache);
-		env_mutex_destroy(&cache->flush_mutex);
 		env_vfree(cache);
 		ocf_ctx_put(ctx);
 	}


### PR DESCRIPTION
Cache lock waiters hold cache refcount. Because of that,
if there were some waiters, deinitialization of cache
lock on the last put did never happen and putting the
cache was effectively impossible.

Fixes #291 

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>