### PR TITLE
Core name - pointer to array change

### DIFF
--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -22,7 +22,7 @@ struct ocf_mngt_core_config {
 	/**
 	 * @brief OCF core name
 	 */
-	const char *name;
+	char name[OCF_CORE_NAME_SIZE];
 
 	/**
 	 * @brief OCF core volume UUID

--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -13,6 +13,7 @@ from ctypes import (
     c_uint16,
     c_uint32,
     c_uint64,
+    c_char,
     c_char_p,
     c_bool,
     cast,
@@ -37,8 +38,9 @@ class UserMetadata(Structure):
 
 
 class CoreConfig(Structure):
+    MAX_CORE_NAME_SIZE = 32
     _fields_ = [
-        ("_name", c_char_p),
+        ("_name", c_char * MAX_CORE_NAME_SIZE),
         ("_uuid", Uuid),
         ("_volume_type", c_uint8),
         ("_try_add", c_bool),
@@ -70,7 +72,7 @@ class Core:
                 ),
                 _size=len(self.device_name) + 1,
             ),
-            _name=cast(create_string_buffer(name.encode("ascii")), c_char_p),
+            _name=name.encode("ascii"),
             _volume_type=self.device.type_id,
             _try_add=try_add,
             _seq_cutoff_threshold=seq_cutoff_threshold,


### PR DESCRIPTION
 **ocf_mngt.h**: In core name change
pointer type to array which is 32 characters long;
**core.py**: Add missing import and modify class' field type
to keep consistency;
**ocf_mngt_core**: Remove local variable 'name';
remove env_vmalloc for 'name' - isn't no longer needed;
remove initialization 'name' - as above;
remove env_vfree for context->cfg.name - variable isn't no allocated
in memory;
check if cfg->name exists;
change label in goto from deleted err_name to the closest err_pipeline.

Signed-off-by: Slawomir_Jankowski <slawomir.jankowski@intel.com>