### PR TITLE
Revert "Optimize cacheline locking in ocf_engine_prepare_clines"

### DIFF
--- a/src/concurrency/ocf_cache_line_concurrency.h
+++ b/src/concurrency/ocf_cache_line_concurrency.h
@@ -54,8 +54,7 @@ size_t ocf_cache_line_concurrency_size_of(struct ocf_cache *cache);
 typedef void (*ocf_req_async_lock_cb)(struct ocf_request *req);
 
 /**
- * @brief Lock OCF request for write access asynchronously. Attempts to lock all
- * cache lines in map info.
+ * @brief Lock OCF request for write access (Lock all cache lines in map info)
  *
  * @param req - OCF request
  * @param cb - async lock acquisition callback
@@ -64,27 +63,12 @@ typedef void (*ocf_req_async_lock_cb)(struct ocf_request *req);
  *		error
  * @retval OCF_LOCK_ACQUIRED - OCF request has been locked and can be processed
  * @retval OCF_LOCK_NOT_ACQUIRED - OCF request lock not acquired, request was
- *		added into waiting list. When lock is acquired, @cb will be
- *		called.
+ * added into waiting list. When lock will be acquired @cb cllback be called
  */
 int ocf_req_async_lock_wr(struct ocf_request *req, ocf_req_async_lock_cb cb);
 
 /**
- * @brief Try to lock OCF request for write access. Serves the same purpose as
- * ocf_req_async_lock_wr, except that this function fails if lock is already
- * held by someone else.
- *
- * @param req - OCF request
- *
- * @returns lock acquisition status
- * @retval OCF_LOCK_ACQUIRED - OCF request has been locked and can be processed
- * @retval OCF_LOCK_NOT_ACQUIRED - OCF request lock not acquired
- */
-int ocf_req_trylock_wr(struct ocf_request *req);
-
-/**
- * @brief Lock OCF request for read access asynchronously. Attempts to lock all
- * cache lines in map info.
+ * @brief Lock OCF request for read access (Lock all cache lines in map info)
  *
  * @param req - OCF request
  * @param cb - async lock acquisition callback
@@ -93,40 +77,26 @@ int ocf_req_trylock_wr(struct ocf_request *req);
  *		error
  * @retval OCF_LOCK_ACQUIRED - OCF request has been locked and can be processed
  * @retval OCF_LOCK_NOT_ACQUIRED - OCF request lock not acquired, request was
- *		added into waiting list. When lock is acquired, @cb will be
- *		called.
+ * added into waiting list. When lock will be acquired @cb callback be called
  */
 int ocf_req_async_lock_rd(struct ocf_request *req, ocf_req_async_lock_cb cb);
 
 /**
- * @brief Try to lock OCF request forread access. Serves the same purpose as
- * ocf_req_async_lock_rd, except that this function fails if lock is already
- * held by someone else.
- *
- * @param req - OCF request
- *
- * @returns lock acquisition status
- * @retval OCF_LOCK_ACQUIRED - OCF request has been locked and can be processed
- * @retval OCF_LOCK_NOT_ACQUIRED - OCF request lock not acquired
- */
-int ocf_req_trylock_rd(struct ocf_request *req);
-
-/**
- * @brief Unlock OCF request from WRITE access
+ * @brief Unlock OCF request from write access
  *
  * @param req - OCF request
  */
 void ocf_req_unlock_wr(struct ocf_request *req);
 
 /**
- * @brief Unlock OCF request from READ access
+ * @brief Unlock OCF request from read access
  *
  * @param req - OCF request
  */
 void ocf_req_unlock_rd(struct ocf_request *req);
 
 /**
- * @brief Unlock OCF request from READ or WRITE access
+ * @brief Unlock OCF request from read or write access
  *
  * @param req - OCF request
  */
@@ -163,7 +133,7 @@ bool ocf_cache_line_are_waiters(struct ocf_cache *cache,
 		ocf_cache_line_t line);
 
 /**
- * @brief un_lock request map info entry from from WRITE or READ access.
+ * @brief un_lock request map info entry from from write or read access.
  *
  * @param cache - OCF cache instance
  * @param req - OCF request

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -235,18 +235,12 @@ static int _ocf_discard_step(struct ocf_request *req)
 
 	if (ocf_engine_mapped_count(req)) {
 		/* Some cache line are mapped, lock request for WRITE access */
-		lock = ocf_req_trylock_wr(req);
+		lock = ocf_req_async_lock_wr(req, _ocf_discard_on_resume);
 	} else {
 		lock = OCF_LOCK_ACQUIRED;
 	}
 
-	if (lock != OCF_LOCK_ACQUIRED) {
-		ocf_req_hash_lock_upgrade(req);
-		lock = ocf_req_async_lock_wr(req, _ocf_discard_on_resume);
-		ocf_req_hash_unlock_wr(req);
-	} else {
-		ocf_req_hash_unlock_rd(req);
-	}
+	ocf_req_hash_unlock_rd(req);
 
 	if (lock >= 0) {
 		if (OCF_LOCK_ACQUIRED == lock) {

--- a/src/engine/engine_fast.c
+++ b/src/engine/engine_fast.c
@@ -195,17 +195,10 @@ int ocf_write_fast(struct ocf_request *req)
 	mapped = ocf_engine_is_mapped(req);
 	if (mapped) {
 		ocf_io_start(&req->ioi.io);
-		lock = ocf_req_trylock_wr(req);
-		if (lock != OCF_LOCK_ACQUIRED) {
-			ocf_req_hash_lock_upgrade(req);
-			lock = ocf_req_async_lock_wr(req, ocf_engine_on_resume);
-			ocf_req_hash_unlock_wr(req);
-		} else {
-			ocf_req_hash_unlock_rd(req);
-		}
-	} else {
-		ocf_req_hash_unlock_rd(req);
+		lock = ocf_req_async_lock_wr(req, ocf_engine_on_resume);
 	}
+
+	ocf_req_hash_unlock_rd(req);
 
 	if (mapped) {
 		if (lock >= 0) {

--- a/src/engine/engine_pt.c
+++ b/src/engine/engine_pt.c
@@ -102,7 +102,7 @@ static const struct ocf_io_if _io_if_pt_resume = {
 int ocf_read_pt(struct ocf_request *req)
 {
 	bool use_cache = false;
-	int lock = OCF_LOCK_ACQUIRED;
+	int lock = OCF_LOCK_NOT_ACQUIRED;
 
 	OCF_DEBUG_TRACE(req->cache);
 
@@ -127,17 +127,14 @@ int ocf_read_pt(struct ocf_request *req)
 			/* There are mapped cache line,
 			 * lock request for READ access
 			 */
-			lock = ocf_req_trylock_rd(req);
+			lock = ocf_req_async_lock_rd(req, ocf_engine_on_resume);
+		} else {
+			/* No mapped cache lines, no need to get lock */
+			lock = OCF_LOCK_ACQUIRED;
 		}
 	}
 
-	if (lock != OCF_LOCK_ACQUIRED) {
-		ocf_req_hash_lock_upgrade(req);
-		lock = ocf_req_async_lock_rd(req, ocf_engine_on_resume);
-		ocf_req_hash_unlock_wr(req);
-	} else {
-		ocf_req_hash_unlock_rd(req);
-	}
+	ocf_req_hash_unlock_rd(req);
 
 	if (use_cache) {
 		/*

--- a/src/engine/engine_wi.c
+++ b/src/engine/engine_wi.c
@@ -154,18 +154,12 @@ int ocf_write_wi(struct ocf_request *req)
 
 	if (ocf_engine_mapped_count(req)) {
 		/* Some cache line are mapped, lock request for WRITE access */
-		lock = ocf_req_trylock_wr(req);
+		lock = ocf_req_async_lock_wr(req, _ocf_write_wi_on_resume);
 	} else {
 		lock = OCF_LOCK_ACQUIRED;
 	}
 
-	if (lock != OCF_LOCK_ACQUIRED) {
-		ocf_req_hash_lock_upgrade(req);
-		lock = ocf_req_async_lock_wr(req, _ocf_write_wi_on_resume);
-		ocf_req_hash_unlock_wr(req);
-	} else {
-		ocf_req_hash_unlock_rd(req);
-	}
+	ocf_req_hash_unlock_rd(req); /*- END Metadata READ access----------------*/
 
 	if (lock >= 0) {
 		if (lock == OCF_LOCK_ACQUIRED) {

--- a/src/engine/engine_wo.c
+++ b/src/engine/engine_wo.c
@@ -223,16 +223,10 @@ int ocf_read_wo(struct ocf_request *req)
 		/* There are mapped cache lines,
 		 * lock request for READ access
 		 */
-		lock = ocf_req_trylock_rd(req);
+		lock = ocf_req_async_lock_rd(req, ocf_engine_on_resume);
 	}
 
-	if (lock != OCF_LOCK_ACQUIRED) {
-		ocf_req_hash_lock_upgrade(req);
-		lock = ocf_req_async_lock_rd(req, ocf_engine_on_resume);
-		ocf_req_hash_unlock_wr(req);
-	} else {
-		ocf_req_hash_unlock_rd(req);
-	}
+	ocf_req_hash_unlock_rd(req); /*- END Metadata RD access -----------------*/
 
 	if (lock >= 0) {
 		if (lock != OCF_LOCK_ACQUIRED) {


### PR DESCRIPTION
This change introduced a race condition. In some code paths after
cacheline trylock failed, hash bucket lock needed bo be upgraded
in order to obtain asynchronous lock. During hash bucket lock
upgrade, hash read locks were released followed by obtaining
hash write locks. After read locks were released, concurrent
thread could obtain hash bucket locks and modify cacheline
state. The thread upgrading hash bucket lock would need to
repeat traversation in order to safely continue.

This reverts commit 30f22d4f471af525671e19595023534f29e287e2.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>