### PR TITLE
Reset initial ioclass stats value when retrieving.

### DIFF
--- a/src/ocf_stats_builder.c
+++ b/src/ocf_stats_builder.c
@@ -289,7 +289,7 @@ int ocf_stats_collect_part_cache(ocf_cache_t cache, ocf_part_id_t part_id,
 		struct ocf_stats_blocks *blocks)
 {
 	struct io_class_stats_context ctx;
-	struct ocf_stats_io_class s;
+	struct ocf_stats_io_class s = {};
 	int result = 0;
 
 	OCF_CHECK_NULL(cache);


### PR DESCRIPTION
Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>