### PR TITLE
Fix counting occupancy on WB write insert error

### DIFF
--- a/src/engine/engine_wb.c
+++ b/src/engine/engine_wb.c
@@ -8,6 +8,7 @@
 #include "cache_engine.h"
 #include "engine_common.h"
 #include "engine_wb.h"
+#include "engine_inv.h"
 #include "../metadata/metadata.h"
 #include "../ocf_request.h"
 #include "../utils/utils_io.h"
@@ -98,11 +99,9 @@ static void _ocf_write_wb_complete(struct ocf_request *req, int error)
 	if (req->error) {
 		ocf_engine_error(req, true, "Failed to write data to cache");
 
-		ocf_req_unlock_wr(req);
-
 		req->complete(req, req->error);
 
-		ocf_req_put(req);
+		ocf_engine_invalidate(req);
 	} else {
 		ocf_engine_push_req_front_if(req, &_io_if_wb_flush_metadata,
 				true);


### PR DESCRIPTION
During error handling in WB write insert we didn't invalidate affected
cache lines. Because of that the cache stopped properly (as it's
supposed to), but cache lines were marked as inserted which caused
occupancy stats to increase even though nothing was succesfully
inserted.

Signed-off-by: Jan Musial <jan.musial@intel.com>