### PR TITLE
ut: Replace deprecated 'commands' module with 'subprocess'

### DIFF
--- a/tests/unit/tests/add_new_test_file.py
+++ b/tests/unit/tests/add_new_test_file.py
@@ -5,15 +5,19 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-import commands
+import subprocess
 import sys
 import os
+
 
 args = ' '.join(sys.argv[1:])
 script_path = os.path.dirname(os.path.realpath(__file__))
 framework_script_path = os.path.join(script_path, "../framework/add_new_test_file.py")
 framework_script_path = os.path.normpath(framework_script_path)
-status, output = commands.getstatusoutput(framework_script_path + " " + args)
+result = subprocess.run(framework_script_path + " " + args, shell=True,
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+status = result.returncode
+output = result.stdout.decode("ASCII", errors='ignore')
 
 print(output)
 


### PR DESCRIPTION
The 'commands' modules has been removed in python 3.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>