### PR TITLE
Change error code

### DIFF
--- a/inc/ocf_err.h
+++ b/inc/ocf_err.h
@@ -117,8 +117,11 @@ typedef enum {
 	/** Invalid cache line size */
 	OCF_ERR_INVALID_CACHE_LINE_SIZE,
 
-	/** Invalid cache name loaded*/
+	/** Invalid cache name loaded */
 	OCF_ERR_CACHE_NAME_MISMATCH,
+
+	/** Device does not meet requirements */
+	OCF_ERR_INVAL_CACHE_DEV,
 } ocf_error_t;
 
 #endif /* __OCF_ERR_H__ */

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -635,7 +635,7 @@ static void _ocf_mngt_attach_cache_device(ocf_pipeline_t pipeline,
 	if (context->volume_size < OCF_CACHE_SIZE_MIN) {
 		ocf_cache_log(cache, log_err, "ERROR: Cache cache size must "
 			"be at least %llu [MiB]\n", OCF_CACHE_SIZE_MIN / MiB);
-		OCF_PL_FINISH_RET(context->pipeline, -OCF_ERR_START_CACHE_FAIL);
+		OCF_PL_FINISH_RET(context->pipeline, -OCF_ERR_INVAL_CACHE_DEV);
 	}
 
 	ocf_pipeline_next(pipeline);
@@ -1211,7 +1211,7 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 	result = ocf_metadata_init(tmp_cache, params.metadata.line_size);
 	if (result) {
 		env_rmutex_unlock(&ctx->lock);
-		result =  -OCF_ERR_START_CACHE_FAIL;
+		result =  -OCF_ERR_NO_MEM;
 		goto _cache_mngt_init_instance_ERROR;
 	}
 	params.flags.metadata_inited = true;

--- a/tests/functional/pyocf/types/shared.py
+++ b/tests/functional/pyocf/types/shared.py
@@ -47,6 +47,7 @@ class OcfErrorCode(IntEnum):
     OCF_ERR_INVALID_CACHE_MODE = auto()
     OCF_ERR_INVALID_CACHE_LINE_SIZE = auto()
     OCF_ERR_CACHE_NAME_MISMATCH = auto()
+    OCF_ERR_INVAL_CACHE_DEV = auto()
 
 
 class OcfCompletion:

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -359,7 +359,7 @@ def test_start_too_small_device(pyocf_ctx, mode, cls):
 
     cache_device = Volume(Size.from_B(20 * 1024 * 1024 - 1))
 
-    with pytest.raises(OcfError, match="OCF_ERR_START_CACHE_FAIL"):
+    with pytest.raises(OcfError, match="OCF_ERR_INVAL_CACHE_DEV"):
         Cache.start_on_device(cache_device, cache_mode=mode, cache_line_size=cls)
 
 


### PR DESCRIPTION
Change 'OCF_ERR_START_CACHE_FAIL' to 'OCF_ERR_NO_MEM' while CAS fails in case of memory lack on device.
closes #317 issue

Signed-off-by: Ostrokrzew <slawomir.jankowski@intel.com>