### PR TITLE
Put a queue before calling cleaner completion callback

### DIFF
--- a/src/cleaning/cleaning.c
+++ b/src/cleaning/cleaning.c
@@ -109,9 +109,8 @@ static void ocf_cleaner_run_complete(ocf_cleaner_t cleaner, uint32_t interval)
 	ocf_cache_t cache = ocf_cleaner_get_cache(cleaner);
 
 	ocf_mngt_cache_unlock(cache);
-	cleaner->end(cleaner, interval);
-
 	ocf_queue_put(cleaner->io_queue);
+	cleaner->end(cleaner, interval);
 }
 
 void ocf_cleaner_run(ocf_cleaner_t cleaner, ocf_queue_t queue)


### PR DESCRIPTION
This ensures that cleaner queue will not be changed
by starting another cleaning iteration before we put it.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>