### PR TITLE
cleaner: Retrieve core object properly

### DIFF
--- a/src/utils/utils_cleaner.c
+++ b/src/utils/utils_cleaner.c
@@ -467,11 +467,12 @@ static void _ocf_cleaner_core_io_cmpl(struct ocf_io *io, int error)
 {
 	struct ocf_map_info *map = io->priv1;
 	struct ocf_request *req = io->priv2;
+	ocf_core_t core = ocf_cache_get_core(req->cache, map->core_id);
 
 	if (error) {
 		map->invalid |= 1;
 		_ocf_cleaner_set_error(req);
-		ocf_core_stats_core_error_update(req->core, OCF_WRITE);
+		ocf_core_stats_core_error_update(core, OCF_WRITE);
 	}
 
 	_ocf_cleaner_core_io_end(req);


### PR DESCRIPTION
Cleaner doesn't set core object in req as it works in domain of cache
lines, which may belong to various cores. It this case should retrieve
core object not from the req, but from the map instead.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>