### PR TITLE
Keep stop pipeline in struct cache.

### DIFF
--- a/src/ocf_cache_priv.h
+++ b/src/ocf_cache_priv.h
@@ -14,6 +14,7 @@
 #include "metadata/metadata_partition_structs.h"
 #include "metadata/metadata_updater_priv.h"
 #include "utils/utils_list.h"
+#include "utils/utils_pipeline.h"
 #include "utils/utils_refcnt.h"
 #include "utils/utils_async_lock.h"
 #include "ocf_stats_priv.h"
@@ -166,6 +167,8 @@ struct ocf_cache {
 	bool use_submit_io_fast;
 
 	struct ocf_trace trace;
+
+	ocf_pipeline_t stop_pipeline;
 
 	void *priv;
 };


### PR DESCRIPTION
To eliminate possibility of allocation error in cache stop, pipeline is
allocated on attach.

Due this change, stop won't return any error, so adapter don't need to care
about rollbacks.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>