### PR TITLE
Fix nhit deadlock

### DIFF
--- a/src/promotion/nhit/nhit.c
+++ b/src/promotion/nhit/nhit.c
@@ -44,6 +44,8 @@ ocf_error_t nhit_init(ocf_cache_t cache)
 		goto dealloc_ctx;
 
 	cache->promotion_policy->ctx = ctx;
+	cache->promotion_policy->config =
+		(void *) &cache->conf_meta->promotion[ocf_promotion_nhit].data;
 
 	return 0;
 
@@ -201,8 +203,9 @@ bool nhit_req_should_promote(ocf_promotion_policy_t policy,
 
 	if (occupied_cachelines < OCF_DIV_ROUND_UP(
 			((uint64_t)cfg->trigger_threshold *
-			ocf_metadata_get_cachelines_count(policy->owner)), 100))
+			ocf_metadata_get_cachelines_count(policy->owner)), 100)) {
 		return true;
+	}
 
 	for (i = 0, core_line = req->core_line_first;
 			core_line <= req->core_line_last; core_line++, i++) {

--- a/src/promotion/nhit/nhit_hash.c
+++ b/src/promotion/nhit/nhit_hash.c
@@ -312,7 +312,7 @@ static inline void write_lock_hashes(nhit_hash_t ctx, ocf_core_id_t core_id1,
 	if (lock_order[0] != ctx->hash_entries)
 		env_rwsem_down_write(&ctx->hash_locks[lock_order[0]]);
 
-	if (lock_order[1] != ctx->hash_entries)
+	if ((lock_order[1] != ctx->hash_entries) && (lock_order[0] != lock_order[1]))
 		env_rwsem_down_write(&ctx->hash_locks[lock_order[1]]);
 }
 
@@ -327,7 +327,7 @@ static inline void write_unlock_hashes(nhit_hash_t ctx, ocf_core_id_t core_id1,
 	if (hash1 != ctx->hash_entries)
 		env_rwsem_up_write(&ctx->hash_locks[hash1]);
 
-	if (hash2 != ctx->hash_entries)
+	if ((hash2 != ctx->hash_entries) && (hash1 != hash2))
 		env_rwsem_up_write(&ctx->hash_locks[hash2]);
 }
 


### PR DESCRIPTION
* Avoid deadlock by eliminating possibility of NHIT promotion policy taking the same semaphore twice
* Fix styling in some places

Fixes: #328 