### PR TITLE
Moved setting ctx for temporary cache object before metadata init

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -1206,6 +1206,7 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 	}
 
 	tmp_cache = params.cache;
+	tmp_cache->owner = ctx;
 
 	/*
 	 * Initialize metadata selected segments of metadata in memory
@@ -1217,8 +1218,6 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 		goto _cache_mngt_init_instance_ERROR;
 	}
 	params.flags.metadata_inited = true;
-
-	tmp_cache->owner = ctx;
 
 	result = ocf_cache_set_name(tmp_cache, cfg->name, OCF_CACHE_NAME_SIZE);
 	if (result) {


### PR DESCRIPTION
This way debug prints during metadata init phase won't cause crash
(because of the fact that temporary cache object does not have proper
ctx set hence does not have logger obj).

Fixes: https://github.com/Open-CAS/open-cas-linux/issues/281

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>