### PR TITLE
Reject discard IOs with size = 0

### DIFF
--- a/inc/ocf_metadata.h
+++ b/inc/ocf_metadata.h
@@ -28,7 +28,7 @@ struct ocf_atomic_metadata {
 	/** Set bit indicates that given sector is valid (is cached) */
 	uint32_t valid : 1;
 
-	/** Set bit indicates that sector i dirty */
+	/** Set bit indicates that sector is dirty */
 	uint32_t dirty : 1;
 } __attribute__((packed));
 

--- a/src/engine/cache_engine.c
+++ b/src/engine/cache_engine.c
@@ -116,7 +116,7 @@ const struct ocf_io_if *ocf_get_io_if(ocf_req_cache_mode_t req_cache_mode)
 	return cache_mode_io_if_map[req_cache_mode];
 }
 
-struct ocf_request *ocf_engine_pop_req(ocf_cache_t cache, ocf_queue_t q)
+struct ocf_request *ocf_engine_pop_req(ocf_queue_t q)
 {
 	unsigned long lock_flags = 0;
 	struct ocf_request *req;

--- a/src/engine/cache_engine.h
+++ b/src/engine/cache_engine.h
@@ -66,8 +66,7 @@ static inline bool ocf_req_cache_mode_has_lazy_write(ocf_req_cache_mode_t mode)
 
 bool ocf_fallback_pt_is_on(ocf_cache_t cache);
 
-struct ocf_request *ocf_engine_pop_req(struct ocf_cache *cache,
-		struct ocf_queue *q);
+struct ocf_request *ocf_engine_pop_req(struct ocf_queue *q);
 
 int ocf_engine_hndl_req(struct ocf_request *req);
 

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -392,6 +392,11 @@ static void ocf_core_volume_submit_discard(struct ocf_io *io)
 
 	OCF_CHECK_NULL(io);
 
+	if (io->bytes == 0) {
+		ocf_io_end(io, -OCF_ERR_INVAL);
+		return;
+	}
+
 	ret = ocf_core_validate_io(io);
 	if (ret < 0) {
 		ocf_io_end(io, ret);

--- a/src/ocf_queue.c
+++ b/src/ocf_queue.c
@@ -86,13 +86,10 @@ void ocf_io_handle(struct ocf_io *io, void *opaque)
 void ocf_queue_run_single(ocf_queue_t q)
 {
 	struct ocf_request *io_req = NULL;
-	ocf_cache_t cache;
 
 	OCF_CHECK_NULL(q);
 
-	cache = q->cache;
-
-	io_req = ocf_engine_pop_req(cache, q);
+	io_req = ocf_engine_pop_req(q);
 
 	if (!io_req)
 		return;

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -159,7 +159,7 @@ struct ocf_request {
 	/*! Last core line */
 
 	uint32_t byte_length;
-	/*!< Byte length of OCF reuqest */
+	/*!< Byte length of OCF request */
 
 	uint32_t core_line_count;
 	/*! Core line count */


### PR DESCRIPTION
Reject zero-size IOs - return *invalid input parameter value* error.
Add test for above case.
Fix some typos.
Remove unused parameters from code.

Fix #353