### PR TITLE
Disable loading cache with 'force' flag

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2075,7 +2075,7 @@ void ocf_mngt_cache_load(ocf_cache_t cache,
 
 	/* Load is not allowed in volatile metadata mode */
 	if (cache->metadata.is_volatile)
-		OCF_CMPL_RET(cache, priv, -EINVAL);
+		OCF_CMPL_RET(cache, priv, -OCF_ERR_INVAL);
 
 	/* Load is not allowed with 'force' flag on */
 	if (cfg->force) {

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2077,6 +2077,13 @@ void ocf_mngt_cache_load(ocf_cache_t cache,
 	if (cache->metadata.is_volatile)
 		OCF_CMPL_RET(cache, priv, -EINVAL);
 
+	/* Load is not allowed with 'force' flag on */
+	if (cfg->force) {
+		ocf_cache_log(cache, log_err, "Using 'force' flag is forbidden "
+				"for load operation.");
+		OCF_CMPL_RET(cache, priv, -OCF_ERR_INVAL);
+	}
+
 	result = _ocf_mngt_cache_validate_device_cfg(cfg);
 	if (result)
 		OCF_CMPL_RET(cache, priv, result);


### PR DESCRIPTION
Fail `ocf_mngt_cache_load` function with `EINVAL` error code
when force flag is in use.
Log error message.

Closes #361

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>