### PR TITLE
WO: read clean sectors from cache

### DIFF
--- a/src/engine/engine_common.h
+++ b/src/engine/engine_common.h
@@ -141,6 +141,19 @@ bool ocf_engine_map_all_sec_clean(struct ocf_request *req, uint32_t line)
 			start, end);
 }
 
+static inline
+bool ocf_engine_map_all_sec_valid(struct ocf_request *req, uint32_t line)
+{
+	uint8_t start = ocf_map_line_start_sector(req, line);
+	uint8_t end = ocf_map_line_end_sector(req, line);
+
+	if (req->map[line].status != LOOKUP_HIT)
+		return false;
+
+	return metadata_test_valid_sec(req->cache, req->map[line].coll_idx,
+			start, end);
+}
+
 /**
  * @brief Clean request (flush dirty data to the core device)
  *


### PR DESCRIPTION
In case of partial hit WO engine first reads data for the entire
request address range from core device. Then it plumbs it by fetching
dirty sectors from cache device.

For unindentified reason this leads to a data corruption in YCSB
workload A. After flushing dirty data and re-loading cache the
data is correct.

This change modifies WO read handler to read clean data from the
cache. This is not optimal, as the clean sectors are now read twice
in case of partial hit. For now it seems to be good enough work-around
for the data corruption problem.

The symptoms, combined with the fact that this change seems to make
the problem go away, indicates that at some point WB write handler
(and/or special I/O request handlers like discard) puts CAS in a
state where in-memory medata wrongly indicates that a sector is
clean while in fact it is dirty, as marked in the on-disk metadata.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>