### PR TITLE
Per-partition max occupancy

### DIFF
--- a/inc/ocf_io_class.h
+++ b/inc/ocf_io_class.h
@@ -40,8 +40,8 @@ struct ocf_io_class_info {
 
 	uint32_t max_size;
 		/*!< Maximum number of cache lines that might be assigned into
-		 * this IO class. If current size reach maximum size no more
-		 * allocation for this IO class takes place
+		 * this IO class. If current size reach maximum size then some
+		 * of ioclass's cachelines are evicted.
 		 */
 
 	uint8_t eviction_policy_type;

--- a/src/metadata/metadata_hash.c
+++ b/src/metadata/metadata_hash.c
@@ -1903,6 +1903,8 @@ static void _recovery_rebuild_cline_metadata(ocf_cache_t cache,
 	env_atomic_inc(&core->runtime_meta->cached_clines);
 	env_atomic_inc(&core->runtime_meta->
 			part_counters[part_id].cached_clines);
+	env_atomic_inc(&core->runtime_meta->
+			part_counters[part_id].valid_cnt);
 
 	if (metadata_test_dirty(cache, cache_line)) {
 		env_atomic_inc(&core->runtime_meta->dirty_clines);

--- a/src/metadata/metadata_partition_structs.h
+++ b/src/metadata/metadata_partition_structs.h
@@ -28,6 +28,7 @@ struct ocf_user_part_config {
 
 struct ocf_user_part_runtime {
 	uint32_t curr_size;
+	env_atomic valid_cnt;
 	uint32_t head;
 	struct eviction_policy eviction;
 	struct cleaning_policy cleaning;

--- a/src/metadata/metadata_partition_structs.h
+++ b/src/metadata/metadata_partition_structs.h
@@ -11,33 +11,33 @@
 #include "../eviction/eviction.h"
 
 struct ocf_user_part_config {
-        char name[OCF_IO_CLASS_NAME_MAX];
-        uint32_t min_size;
-        uint32_t max_size;
-        int16_t priority;
-        ocf_cache_mode_t cache_mode;
-        struct {
-                uint8_t valid : 1;
-                uint8_t added : 1;
-                uint8_t eviction : 1;
-                        /*!< This bits is setting during partition sorting,
-                         * and means that can evict from this partition
-                         */
-        } flags;
+	char name[OCF_IO_CLASS_NAME_MAX];
+	uint32_t min_size;
+	uint32_t max_size;
+	int16_t priority;
+	ocf_cache_mode_t cache_mode;
+	struct {
+		uint8_t valid : 1;
+		uint8_t added : 1;
+		uint8_t eviction : 1;
+			/*!< This bits is setting during partition sorting,
+			* and means that can evict from this partition
+			*/
+	} flags;
 };
 
 struct ocf_user_part_runtime {
-        uint32_t curr_size;
-        uint32_t head;
-        struct eviction_policy eviction;
-        struct cleaning_policy cleaning;
+	uint32_t curr_size;
+	uint32_t head;
+	struct eviction_policy eviction;
+	struct cleaning_policy cleaning;
 };
 
 struct ocf_user_part {
-        struct ocf_user_part_config *config;
-        struct ocf_user_part_runtime *runtime;
+	struct ocf_user_part_config *config;
+	struct ocf_user_part_runtime *runtime;
 
-        struct ocf_lst_entry lst_valid;
+	struct ocf_lst_entry lst_valid;
 };
 
 

--- a/src/ocf_core_priv.h
+++ b/src/ocf_core_priv.h
@@ -67,6 +67,8 @@ struct ocf_core_meta_runtime {
 		 * cache device
 		 */
 		env_atomic dirty_clines;
+
+		env_atomic valid_cnt;
 	} part_counters[OCF_IO_CLASS_MAX];
 };
 

--- a/src/ocf_io_class.c
+++ b/src/ocf_io_class.c
@@ -13,6 +13,7 @@ int ocf_cache_io_class_get_info(ocf_cache_t cache, uint32_t io_class,
 		struct ocf_io_class_info *info)
 {
 	ocf_part_id_t part_id = io_class;
+	uint32_t cache_occupancy_total = 0;
 
 	OCF_CHECK_NULL(cache);
 
@@ -33,9 +34,14 @@ int ocf_cache_io_class_get_info(ocf_cache_t cache, uint32_t io_class,
 		return -OCF_ERR_INVAL;
 	}
 
+	if (ocf_cache_is_device_attached(cache)) {
+		cache_occupancy_total = env_atomic_read(&cache->
+						user_parts[part_id].runtime->
+						valid_cnt);
+	}
+
 	info->priority = cache->user_parts[part_id].config->priority;
-	info->curr_size = ocf_cache_is_device_attached(cache) ?
-			cache->user_parts[part_id].runtime->curr_size : 0;
+	info->curr_size = cache_occupancy_total;
 	info->min_size = cache->user_parts[part_id].config->min_size;
 	info->max_size = cache->user_parts[part_id].config->max_size;
 

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -188,6 +188,9 @@ struct ocf_request {
 	uint8_t seq_cutoff : 1;
 	/*!< Sequential cut off set for this request */
 
+	uint8_t part_evict : 1;
+	/* !< Some cachelines from request's partition must be evicted */
+
 	log_sid_t sid;
 	/*!< Tracing sequence ID */
 

--- a/src/utils/utils_cache_line.c
+++ b/src/utils/utils_cache_line.c
@@ -37,6 +37,9 @@ static void __set_cache_line_invalid(struct ocf_cache *cache, uint8_t start_bit,
 		env_atomic_dec(&core->runtime_meta->cached_clines);
 		env_atomic_dec(&core->runtime_meta->
 				part_counters[part_id].cached_clines);
+		env_atomic_dec(&cache->user_parts[part_id].runtime->valid_cnt);
+		env_atomic_dec(&core->runtime_meta->
+				part_counters[part_id].valid_cnt);
 	}
 
 	/* If we have waiters, do not remove cache line
@@ -93,6 +96,9 @@ void set_cache_line_valid(struct ocf_cache *cache, uint8_t start_bit,
 		env_atomic_inc(&req->core->runtime_meta->cached_clines);
 		env_atomic_inc(&req->core->runtime_meta->
 				part_counters[part_id].cached_clines);
+		env_atomic_inc(&cache->user_parts[part_id].runtime->valid_cnt);
+		env_atomic_inc(&req->core->runtime_meta->
+				part_counters[part_id].valid_cnt);
 	}
 }
 

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -171,7 +171,7 @@ def test_stop(pyocf_ctx, mode: CacheMode, cls: CacheLineSize, with_flush: bool):
     Check if cache is stopped properly in different modes with or without preceding flush operation.
     """
 
-    cache_device = Volume(Size.from_MiB(20))
+    cache_device = Volume(Size.from_MiB(25))
     core_device = Volume(Size.from_MiB(5))
     cache = Cache.start_on_device(cache_device, cache_mode=mode, cache_line_size=cls)
     core_exported = Core.using_device(core_device)


### PR DESCRIPTION
Respect max occupancy for each partition.
Needed cachelines number is evicted after max occupancy threshold is reached.