### PR TITLE
Set entry->core_id in ocf_engine_lookup_map_entry

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -51,6 +51,7 @@ void ocf_engine_lookup_map_entry(struct ocf_cache *cache,
 	entry->status = LOOKUP_MISS;
 	entry->coll_idx = cache->device->collision_table_entries;
 	entry->core_line = core_line;
+	entry->core_id = core_id;
 
 	line = ocf_metadata_get_hash(cache, hash);
 


### PR DESCRIPTION
core_id should be set in this function. The fact that
it is missing might lead to incorrect behaviour e.g. in
case of promotion policy.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>