### PR TITLE
WO: read clean sectors from cache

### DIFF
--- a/src/engine/engine_common.h
+++ b/src/engine/engine_common.h
@@ -141,6 +141,19 @@ bool ocf_engine_map_all_sec_clean(struct ocf_request *req, uint32_t line)
 			start, end);
 }
 
+static inline
+bool ocf_engine_map_all_sec_valid(struct ocf_request *req, uint32_t line)
+{
+	uint8_t start = ocf_map_line_start_sector(req, line);
+	uint8_t end = ocf_map_line_end_sector(req, line);
+
+	if (req->map[line].status != LOOKUP_HIT)
+		return false;
+
+	return metadata_test_valid_sec(req->cache, req->map[line].coll_idx,
+			start, end);
+}
+
 /**
  * @brief Clean request (flush dirty data to the core device)
  *


### PR DESCRIPTION
So far in case of partial hit WO engine used to first read data for the entire
request address range from core device and then it plumb it by fetching dirty
sectors from cache device. However between reading data from core and from cache
the cleaning could occur, effectively changing status of some cachelines from
dirty to clean. In result, some data which should have been read from the cache
device was not, causing temporary data corruption.

This change modifies WO read handler to read clean data from the cache. This is
not optimal, as the clean sectors are now read twice in case of partial hit,
but it ensures that the read data is always consistent.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>