### PR TITLE
Add missing part->id initialization

### DIFF
--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -570,6 +570,7 @@ static int ocf_metadata_init_fixed_size(struct ocf_cache *cache,
 	for (i = 0; i < OCF_IO_CLASS_MAX + 1; i++) {
 		cache->user_parts[i].config = &part_config[i];
 		cache->user_parts[i].runtime = &part_runtime[i];
+		cache->user_parts[i].id = i;
 	}
 
 	/* Set core metadata */


### PR DESCRIPTION
... it got lost during previous rebasing of metadata interface rework.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>