### PR TITLE
Flush metadata collision segment on core remove

### DIFF
--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -1025,6 +1025,23 @@ void ocf_metadata_flush_all(ocf_cache_t cache,
 }
 
 /*
+ * Flush collision metadata
+ */
+void ocf_metadata_flush_collision(ocf_cache_t cache,
+		ocf_metadata_end_t cmpl, void *priv)
+{
+	struct ocf_metadata_ctrl *ctrl;
+	struct ocf_metadata_raw *raw;
+
+	OCF_DEBUG_TRACE(cache);
+
+	ctrl = cache->metadata.priv;
+	raw = &ctrl->raw_desc[metadata_segment_collision];
+
+	ocf_metadata_raw_flush_all(cache, raw, cmpl, priv);
+}
+
+/*
  * Flush specified cache line
  */
 void ocf_metadata_flush_mark(struct ocf_cache *cache,

--- a/src/metadata/metadata.h
+++ b/src/metadata/metadata.h
@@ -124,6 +124,16 @@ void ocf_metadata_flush_all(ocf_cache_t cache,
 		ocf_metadata_end_t cmpl, void *priv);
 
 /**
+ * @brief Flush metadata collision segment
+ *
+ * @param cache - Cache instance
+ * @param cmpl - Completion callback
+ * @param priv - Completion context
+ */
+void ocf_metadata_flush_collision(ocf_cache_t cache,
+		ocf_metadata_end_t cmpl, void *priv);
+
+/**
  * @brief Mark specified cache line to be flushed
  *
  * @param[in] cache - Cache instance


### PR DESCRIPTION
If there is any dirty data on the cache associated with removed core,
we must flush collision metadata after removing core to make metadata
persistent in case of dirty shutdown.

This fixes the problem when recovery procedure erroneously interprets
cache lines that belonged to removed core as valid ones.

This also fixes the problem, when after removing core containing dirty
data another core is added, and then recovery procedure following dirty
shutdown assigns cache lines from removed core to the new one, effectively
leading to data corruption.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>