### PR TITLE
relax LRU list ordering to minimize list updates

### DIFF
--- a/src/concurrency/ocf_metadata_concurrency.c
+++ b/src/concurrency/ocf_metadata_concurrency.c
@@ -12,11 +12,8 @@ int ocf_metadata_concurrency_init(struct ocf_metadata_lock *metadata_lock)
 	unsigned evp_iter;
 	unsigned part_iter;
 
-	for (evp_iter = 0; evp_iter < OCF_NUM_EVICTION_LISTS; evp_iter++) {
-		err = env_spinlock_init(&metadata_lock->eviction[evp_iter]);
-		if (err)
-			goto eviction_err;
-	}
+	for (evp_iter = 0; evp_iter < OCF_NUM_EVICTION_LISTS; evp_iter++)
+		env_rwlock_init(&metadata_lock->eviction[evp_iter]);
 
 	env_rwlock_init(&metadata_lock->status);
 
@@ -38,9 +35,8 @@ spinlocks_err:
 rwsem_err:
 	env_rwlock_destroy(&metadata_lock->status);
 
-eviction_err:
 	while (evp_iter--)
-		env_spinlock_destroy(&metadata_lock->eviction[evp_iter]);
+		env_rwlock_destroy(&metadata_lock->eviction[evp_iter]);
 
 	return err;
 }
@@ -53,7 +49,7 @@ void ocf_metadata_concurrency_deinit(struct ocf_metadata_lock *metadata_lock)
 		env_spinlock_destroy(&metadata_lock->partition[i]);
 
 	for (i = 0; i < OCF_NUM_EVICTION_LISTS; i++)
-		env_spinlock_destroy(&metadata_lock->eviction[i]);
+		env_rwlock_destroy(&metadata_lock->eviction[i]);
 
 	env_rwlock_destroy(&metadata_lock->status);
 	env_rwsem_destroy(&metadata_lock->global);

--- a/src/concurrency/ocf_metadata_concurrency.h
+++ b/src/concurrency/ocf_metadata_concurrency.h
@@ -22,49 +22,49 @@ int ocf_metadata_concurrency_attached_init(
 void ocf_metadata_concurrency_attached_deinit(
 		struct ocf_metadata_lock *metadata_lock);
 
-static inline void ocf_metadata_eviction_lock(
+static inline void ocf_metadata_eviction_wr_lock(
 		struct ocf_metadata_lock *metadata_lock, unsigned ev_list)
 {
-	env_spinlock_lock(&metadata_lock->eviction[ev_list]);
+	env_rwlock_write_lock(&metadata_lock->eviction[ev_list]);
 }
 
-static inline void ocf_metadata_eviction_unlock(
+static inline void ocf_metadata_eviction_wr_unlock(
 		struct ocf_metadata_lock *metadata_lock, unsigned ev_list)
 {
-	env_spinlock_unlock(&metadata_lock->eviction[ev_list]);
+	env_rwlock_write_unlock(&metadata_lock->eviction[ev_list]);
 }
 
-static inline void ocf_metadata_eviction_lock_all(
+static inline void ocf_metadata_eviction_wr_lock_all(
 		struct ocf_metadata_lock *metadata_lock)
 {
 	uint32_t i;
 
 	for (i = 0; i < OCF_NUM_EVICTION_LISTS; i++)
-		ocf_metadata_eviction_lock(metadata_lock, i);
+		ocf_metadata_eviction_wr_lock(metadata_lock, i);
 }
 
-static inline void ocf_metadata_eviction_unlock_all(
+static inline void ocf_metadata_eviction_wr_unlock_all(
 		struct ocf_metadata_lock *metadata_lock)
 {
 	uint32_t i;
 
 	for (i = 0; i < OCF_NUM_EVICTION_LISTS; i++)
-		ocf_metadata_eviction_unlock(metadata_lock, i);
+		ocf_metadata_eviction_wr_unlock(metadata_lock, i);
 }
 
-#define OCF_METADATA_EVICTION_LOCK(cline) \
-		ocf_metadata_eviction_lock(&cache->metadata.lock, \
+#define OCF_METADATA_EVICTION_WR_LOCK(cline) \
+		ocf_metadata_eviction_wr_lock(&cache->metadata.lock, \
 				cline % OCF_NUM_EVICTION_LISTS)
 
-#define OCF_METADATA_EVICTION_UNLOCK(cline) \
-		ocf_metadata_eviction_unlock(&cache->metadata.lock, \
+#define OCF_METADATA_EVICTION_WR_UNLOCK(cline) \
+		ocf_metadata_eviction_wr_unlock(&cache->metadata.lock, \
 				cline % OCF_NUM_EVICTION_LISTS)
 
-#define OCF_METADATA_EVICTION_LOCK_ALL() \
-	ocf_metadata_eviction_lock_all(&cache->metadata.lock)
+#define OCF_METADATA_EVICTION_WR_LOCK_ALL() \
+	ocf_metadata_eviction_wr_lock_all(&cache->metadata.lock)
 
-#define OCF_METADATA_EVICTION_UNLOCK_ALL() \
-	ocf_metadata_eviction_unlock_all(&cache->metadata.lock)
+#define OCF_METADATA_EVICTION_WR_UNLOCK_ALL() \
+	ocf_metadata_eviction_wr_unlock_all(&cache->metadata.lock)
 
 static inline void ocf_metadata_partition_lock(
 		struct ocf_metadata_lock *metadata_lock,

--- a/src/concurrency/ocf_metadata_concurrency.h
+++ b/src/concurrency/ocf_metadata_concurrency.h
@@ -34,6 +34,17 @@ static inline void ocf_metadata_eviction_wr_unlock(
 	env_rwlock_write_unlock(&metadata_lock->eviction[ev_list]);
 }
 
+static inline void ocf_metadata_eviction_rd_lock(
+		struct ocf_metadata_lock *metadata_lock, unsigned ev_list)
+{
+	env_rwlock_read_lock(&metadata_lock->eviction[ev_list]);
+}
+
+static inline void ocf_metadata_eviction_rd_unlock(
+		struct ocf_metadata_lock *metadata_lock, unsigned ev_list)
+{
+	env_rwlock_read_unlock(&metadata_lock->eviction[ev_list]);
+}
 static inline void ocf_metadata_eviction_wr_lock_all(
 		struct ocf_metadata_lock *metadata_lock)
 {
@@ -59,6 +70,15 @@ static inline void ocf_metadata_eviction_wr_unlock_all(
 #define OCF_METADATA_EVICTION_WR_UNLOCK(cline) \
 		ocf_metadata_eviction_wr_unlock(&cache->metadata.lock, \
 				cline % OCF_NUM_EVICTION_LISTS)
+
+#define OCF_METADATA_EVICTION_RD_LOCK(cline) \
+		ocf_metadata_eviction_rd_lock(&cache->metadata.lock, \
+				cline % OCF_NUM_EVICTION_LISTS)
+
+#define OCF_METADATA_EVICTION_RD_UNLOCK(cline) \
+		ocf_metadata_eviction_rd_unlock(&cache->metadata.lock, \
+				cline % OCF_NUM_EVICTION_LISTS)
+
 
 #define OCF_METADATA_EVICTION_WR_LOCK_ALL() \
 	ocf_metadata_eviction_wr_lock_all(&cache->metadata.lock)

--- a/src/eviction/lru.c
+++ b/src/eviction/lru.c
@@ -583,11 +583,11 @@ void evp_lru_clean_cline(ocf_cache_t cache, struct ocf_user_part *part,
 	clean_list = evp_lru_get_list(part, ev_list, true);
 	dirty_list = evp_lru_get_list(part, ev_list, false);
 
-	OCF_METADATA_EVICTION_LOCK(cline);
+	OCF_METADATA_EVICTION_WR_LOCK(cline);
 	remove_lru_list(cache, dirty_list, cline);
 	add_lru_head(cache, clean_list, cline);
 	balance_lru_list(cache, clean_list);
-	OCF_METADATA_EVICTION_UNLOCK(cline);
+	OCF_METADATA_EVICTION_WR_UNLOCK(cline);
 }
 
 void evp_lru_dirty_cline(ocf_cache_t cache, struct ocf_user_part *part,
@@ -600,10 +600,10 @@ void evp_lru_dirty_cline(ocf_cache_t cache, struct ocf_user_part *part,
 	clean_list = evp_lru_get_list(part, ev_list, true);
 	dirty_list = evp_lru_get_list(part, ev_list, false);
 
-	OCF_METADATA_EVICTION_LOCK(cline);
+	OCF_METADATA_EVICTION_WR_LOCK(cline);
 	remove_lru_list(cache, clean_list, cline);
 	add_lru_head(cache, dirty_list, cline);
 	balance_lru_list(cache, dirty_list);
-	OCF_METADATA_EVICTION_UNLOCK(cline);
+	OCF_METADATA_EVICTION_WR_UNLOCK(cline);
 }
 

--- a/src/eviction/lru_structs.h
+++ b/src/eviction/lru_structs.h
@@ -10,17 +10,22 @@ struct lru_eviction_policy_meta {
 	/* LRU pointers 2*4=8 bytes */
 	uint32_t prev;
 	uint32_t next;
+	uint32_t hot;
 } __attribute__((packed));
 
 struct ocf_lru_list {
 	uint32_t num_nodes;
 	uint32_t head;
 	uint32_t tail;
+	uint32_t num_hot;
+	uint32_t last_hot;
 };
 
 struct lru_eviction_policy {
 	struct ocf_lru_list clean;
 	struct ocf_lru_list dirty;
 };
+
+#define OCF_LRU_HOT_RATIO 2
 
 #endif

--- a/src/eviction/ops.h
+++ b/src/eviction/ops.h
@@ -36,9 +36,9 @@ static inline void ocf_eviction_purge_cache_line(
 	ENV_BUG_ON(type >= ocf_eviction_max);
 
 	if (likely(evict_policy_ops[type].rm_cline)) {
-		OCF_METADATA_EVICTION_LOCK(line);
+		OCF_METADATA_EVICTION_WR_LOCK(line);
 		evict_policy_ops[type].rm_cline(cache, line);
-		OCF_METADATA_EVICTION_UNLOCK(line);
+		OCF_METADATA_EVICTION_WR_UNLOCK(line);
 	}
 }
 
@@ -83,9 +83,9 @@ static inline void ocf_eviction_set_hot_cache_line(
 	ENV_BUG_ON(type >= ocf_eviction_max);
 
 	if (likely(evict_policy_ops[type].hot_cline)) {
-		OCF_METADATA_EVICTION_LOCK(line);
+		OCF_METADATA_EVICTION_WR_LOCK(line);
 		evict_policy_ops[type].hot_cline(cache, line);
-		OCF_METADATA_EVICTION_UNLOCK(line);
+		OCF_METADATA_EVICTION_WR_UNLOCK(line);
 	}
 }
 
@@ -97,9 +97,9 @@ static inline void ocf_eviction_initialize(struct ocf_cache *cache,
 	ENV_BUG_ON(type >= ocf_eviction_max);
 
 	if (likely(evict_policy_ops[type].init_evp)) {
-		OCF_METADATA_EVICTION_LOCK_ALL();
+		OCF_METADATA_EVICTION_WR_LOCK_ALL();
 		evict_policy_ops[type].init_evp(cache, part);
-		OCF_METADATA_EVICTION_UNLOCK_ALL();
+		OCF_METADATA_EVICTION_WR_UNLOCK_ALL();
 	}
 }
 

--- a/src/eviction/ops.h
+++ b/src/eviction/ops.h
@@ -83,9 +83,7 @@ static inline void ocf_eviction_set_hot_cache_line(
 	ENV_BUG_ON(type >= ocf_eviction_max);
 
 	if (likely(evict_policy_ops[type].hot_cline)) {
-		OCF_METADATA_EVICTION_WR_LOCK(line);
 		evict_policy_ops[type].hot_cline(cache, line);
-		OCF_METADATA_EVICTION_WR_UNLOCK(line);
 	}
 }
 

--- a/src/metadata/metadata_structs.h
+++ b/src/metadata/metadata_structs.h
@@ -47,7 +47,7 @@ struct ocf_metadata_lock
 {
 	env_rwsem global; /*!< global metadata lock (GML) */
 	env_rwlock status; /*!< Fast lock for status bits */
-	env_spinlock eviction[OCF_NUM_EVICTION_LISTS]; /*!< Fast lock for eviction policy */
+	env_rwlock eviction[OCF_NUM_EVICTION_LISTS]; /*!< Fast lock for eviction policy */
 	env_rwsem *hash; /*!< Hash bucket locks */
 	env_rwsem *collision_pages; /*!< Collision table page locks */
 	env_spinlock partition[OCF_IO_CLASS_MAX]; /* partition lock */

--- a/tests/unit/tests/eviction/lru.c/lru.c
+++ b/tests/unit/tests/eviction/lru.c/lru.c
@@ -1,0 +1,323 @@
+/*
+ * <tested_file_path>src/eviction/lru.c</tested_file_path>
+ * <tested_function>_lru_init</tested_function>
+ * <functions_to_leave>
+ * 	update_lru_head
+ * 	update_lru_tail
+ * 	update_lru_head_tail
+ *      _lru_init
+ * 	add_lru_head
+ * 	remove_lru_list
+ * 	balance_lru_list
+ * </functions_to_leave>
+ */
+
+#undef static
+
+#undef inline
+
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "print_desc.h"
+
+#include "eviction.h"
+#include "lru.h"
+#include "ops.h"
+#include "../utils/utils_cleaner.h"
+#include "../utils/utils_cache_line.h"
+#include "../concurrency/ocf_concurrency.h"
+#include "../mngt/ocf_mngt_common.h"
+#include "../engine/engine_zero.h"
+#include "../ocf_request.h"
+
+#include "eviction/lru.c/lru_generated_wraps.c"
+
+#define META_COUNT 128
+
+static union eviction_policy_meta meta[META_COUNT];
+
+union eviction_policy_meta*
+__wrap_ocf_metadata_get_eviction_policy(ocf_cache_t cache, ocf_cache_line_t line)
+{
+	assert (line < META_COUNT);
+	return &meta[line];
+}
+
+static const unsigned end_marker = -1;
+
+static void _lru_init_test01(void **state)
+{
+	struct ocf_lru_list l;
+
+	print_test_description("test init\n");
+
+	_lru_init(&l, end_marker);
+
+	assert_int_equal(l.num_hot, 0);
+	assert_int_equal(l.num_nodes, 0);
+	assert_int_equal(l.head, end_marker);
+	assert_int_equal(l.tail, end_marker);
+	assert_int_equal(l.last_hot, end_marker);
+
+	assert_int_equal(1,1);
+}
+
+static void check_hot_elems(struct ocf_lru_list *l)
+{
+	unsigned i;
+	unsigned curr = l->head;
+
+	for (i = 0; i < l->num_hot; i++) {
+		assert_int_equal(meta[curr].lru.hot, 1);
+		curr = meta[curr].lru.next;
+	}
+	for (i = l->num_hot; i < l->num_nodes; i++) {
+		assert_int_equal(meta[curr].lru.hot, 0);
+		curr = meta[curr].lru.next;
+	}
+}
+
+static void _lru_init_test02(void **state)
+{
+	struct ocf_lru_list l;
+	unsigned i;
+
+	memset(meta, 0, sizeof(meta));
+
+	print_test_description("test add\n");
+
+	_lru_init(&l, end_marker);
+
+	for (i = 1; i <= 8; i++)
+	{
+		add_lru_head(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+		assert_int_equal(l.num_hot, i / 2);
+		assert_int_equal(l.num_nodes, i);
+		assert_int_equal(l.head, i);
+		assert_int_equal(l.tail, 1);
+		assert_int_equal(l.last_hot, i < 2 ? end_marker :
+				i - i / 2 + 1);
+		check_hot_elems(&l);
+	}
+}
+
+static void _lru_init_test03(void **state)
+{
+	struct ocf_lru_list l;
+	unsigned i;
+
+	memset(meta, 0, sizeof(meta));
+
+	print_test_description("remove head\n");
+
+	_lru_init(&l, end_marker);
+
+	for (i = 1; i <= 8; i++) {
+		add_lru_head(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	for (i = 8; i >= 1; i--) {
+		assert_int_equal(l.num_hot, i / 2);
+		assert_int_equal(l.num_nodes, i);
+		assert_int_equal(l.head, i);
+		assert_int_equal(l.tail, 1);
+		assert_int_equal(l.last_hot, i < 2 ? end_marker :
+				i - i / 2 + 1);
+		check_hot_elems(&l);
+
+		remove_lru_list(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	assert_int_equal(l.num_hot, 0);
+	assert_int_equal(l.num_nodes, 0);
+	assert_int_equal(l.head, end_marker);
+	assert_int_equal(l.tail, end_marker);
+	assert_int_equal(l.last_hot, end_marker);
+}
+
+static void _lru_init_test04(void **state)
+{
+	struct ocf_lru_list l;
+	unsigned i;
+
+	memset(meta, 0, sizeof(meta));
+
+	print_test_description("remove tail\n");
+
+	_lru_init(&l, end_marker);
+
+	for (i = 1; i <= 8; i++) {
+		add_lru_head(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	for (i = 8; i >= 1; i--) {
+		assert_int_equal(l.num_hot, i / 2);
+		assert_int_equal(l.num_nodes, i);
+		assert_int_equal(l.head, 8);
+		assert_int_equal(l.tail, 9 - i);
+		assert_int_equal(l.last_hot, i < 2 ? end_marker :
+				8 - i / 2 + 1);
+		check_hot_elems(&l);
+
+		remove_lru_list(NULL, &l, 9 - i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	assert_int_equal(l.num_hot, 0);
+	assert_int_equal(l.num_nodes, 0);
+	assert_int_equal(l.head, end_marker);
+	assert_int_equal(l.tail, end_marker);
+	assert_int_equal(l.last_hot, end_marker);
+}
+
+static void _lru_init_test05(void **state)
+{
+	struct ocf_lru_list l;
+	unsigned i, j;
+	bool present[9];
+	unsigned count;
+
+	memset(meta, 0, sizeof(meta));
+
+	print_test_description("remove last hot\n");
+
+	_lru_init(&l, end_marker);
+
+	for (i = 1; i <= 8; i++) {
+		add_lru_head(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+		present[i] = true;
+	}
+
+	for (i = 8; i >= 3; i--) {
+		assert_int_equal(l.num_hot, i / 2);
+		assert_int_equal(l.num_nodes, i);
+		assert_int_equal(l.head, 8);
+		assert_int_equal(l.tail, 1);
+
+		count = 0;
+		j = 8;
+		while (count < i / 2) {
+			if (present[j])
+				++count;
+			--j;
+		}
+
+		assert_int_equal(l.last_hot, j + 1);
+		check_hot_elems(&l);
+
+		present[l.last_hot] = false;
+		remove_lru_list(NULL, &l, l.last_hot, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	assert_int_equal(l.num_hot, 1);
+	assert_int_equal(l.num_nodes, 2);
+	assert_int_equal(l.head, 2);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 2);
+}
+
+static void _lru_init_test06(void **state)
+{
+	struct ocf_lru_list l;
+	unsigned i;
+	unsigned count;
+
+	memset(meta, 0, sizeof(meta));
+
+	print_test_description("remove middle hot\n");
+
+	_lru_init(&l, end_marker);
+
+	for (i = 1; i <= 8; i++) {
+		add_lru_head(NULL, &l, i, end_marker);
+		balance_lru_list(NULL, &l, end_marker);
+	}
+
+	count = 8;
+
+	remove_lru_list(NULL, &l, 7, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 8);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 5);
+
+	remove_lru_list(NULL, &l, 6, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 8);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 4);
+
+	remove_lru_list(NULL, &l, 5, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 8);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 4);
+
+	remove_lru_list(NULL, &l, 4, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 8);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 3);
+
+	remove_lru_list(NULL, &l, 3, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 8);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 8);
+
+	remove_lru_list(NULL, &l, 8, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 2);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, 2);
+
+	remove_lru_list(NULL, &l, 2, end_marker);
+	balance_lru_list(NULL, &l, end_marker);
+	--count;
+	assert_int_equal(l.num_hot, count / 2);
+	assert_int_equal(l.num_nodes, count);
+	assert_int_equal(l.head, 1);
+	assert_int_equal(l.tail, 1);
+	assert_int_equal(l.last_hot, end_marker);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(_lru_init_test01),
+		cmocka_unit_test(_lru_init_test02),
+		cmocka_unit_test(_lru_init_test03),
+		cmocka_unit_test(_lru_init_test04),
+		cmocka_unit_test(_lru_init_test05),
+		cmocka_unit_test(_lru_init_test06)
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Top 50% least recently used cachelines are marked as hot and not promoted to list head upon access. Only after cacheline drops to bottom 50% it is considered as a candidate to promotion to list head.

The purpose of this change is to reduce overhead of LRU list maintenance for hot cachelines.
