### PR TITLE
[v20.12.2] Fix updating hot cachelines cleaning list

### DIFF
--- a/src/engine/engine_wb.c
+++ b/src/engine/engine_wb.c
@@ -13,6 +13,7 @@
 #include "../ocf_request.h"
 #include "../utils/utils_io.h"
 #include "../utils/utils_cache_line.h"
+#include "../utils/utils_request.h"
 #include "../utils/utils_part.h"
 #include "../concurrency/ocf_concurrency.h"
 
@@ -42,6 +43,8 @@ static void _ocf_write_wb_update_bits(struct ocf_request *req)
 
 		ocf_req_hash_unlock_wr(req);
 	}
+
+	ocf_req_set_cleaning_hot(req);
 }
 
 static void _ocf_write_wb_io_flush_metadata(struct ocf_request *req, int error)

--- a/src/utils/utils_cache_line.c
+++ b/src/utils/utils_cache_line.c
@@ -6,7 +6,7 @@
 #include "utils_cache_line.h"
 #include "../promotion/promotion.h"
 
-static inline void ocf_cleaning_set_hot_cache_line(struct ocf_cache *cache,
+void ocf_cleaning_set_hot_cache_line(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
 	ocf_cleaning_t cleaning_type = cache->conf_meta->cleaning_policy_type;

--- a/src/utils/utils_cache_line.h
+++ b/src/utils/utils_cache_line.h
@@ -69,6 +69,9 @@ static inline uint64_t ocf_lines_2_bytes(struct ocf_cache *cache,
 	return lines * ocf_line_size(cache);
 }
 
+void ocf_cleaning_set_hot_cache_line(struct ocf_cache *cache,
+		ocf_cache_line_t line);
+
 /**
  * @brief Set cache line invalid
  *

--- a/src/utils/utils_request.c
+++ b/src/utils/utils_request.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) 2012-2020 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef UTILS_REQUEST_H_
+#define UTILS_REQUEST_H_
+
+#include "utils_request.h"
+#include "utils_cache_line.h"
+
+int ocf_req_actor(struct ocf_request *req, ocf_req_actor_t actor)
+{
+	uint32_t count = req->core_line_count;
+	uint32_t map_idx = 0;
+	int result = 0;
+
+	for (map_idx = 0; map_idx < count; map_idx++) {
+		result = actor(req, map_idx);
+		if (result)
+			break;
+	}
+
+	return result;
+}
+
+static int _set_cleaning_hot_actor(struct ocf_request *req, uint32_t map_idx)
+{
+	ocf_cache_t cache = req->cache;
+	ocf_cache_line_t line = req->map[map_idx].coll_idx;
+
+	ocf_cleaning_set_hot_cache_line(cache, line);
+
+	return 0;
+}
+
+void ocf_req_set_cleaning_hot(struct ocf_request *req)
+{
+	ocf_req_actor(req, _set_cleaning_hot_actor);
+}
+
+#endif

--- a/src/utils/utils_request.h
+++ b/src/utils/utils_request.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright(c) 2012-2021 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include "../ocf_request.h"
+#include "../ocf_cache_priv.h"
+
+typedef int (*ocf_req_actor_t)(struct ocf_request *req, uint32_t map_idx);
+
+int ocf_req_actor(struct ocf_request *req, ocf_req_actor_t actor);
+
+void ocf_req_set_cleaning_hot(struct ocf_request *req);


### PR DESCRIPTION
Update cacheline's timestamp each time it's being written.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>