### PR TITLE
Fix `ocf_engine_unmapped_count()`

### DIFF
--- a/src/engine/engine_common.h
+++ b/src/engine/engine_common.h
@@ -109,7 +109,8 @@ static inline uint32_t ocf_engine_mapped_count(struct ocf_request *req)
  */
 static inline uint32_t ocf_engine_unmapped_count(struct ocf_request *req)
 {
-	return req->core_line_count - (req->info.hit_no + req->info.invalid_no);
+	return req->core_line_count -
+		(req->info.hit_no + req->info.invalid_no + req->info.insert_no);
 }
 
 void ocf_map_cache_line(struct ocf_request *req,

--- a/src/eviction/lru.c
+++ b/src/eviction/lru.c
@@ -683,6 +683,8 @@ uint32_t evp_lru_req_clines(struct ocf_request *req,
 
 		++req_idx;
 		++i;
+		/* Number of cachelines to evict have to match space in the request */
+		ENV_BUG_ON(req_idx == req->core_line_count && i != cline_no );
 	}
 
 	return i;


### PR DESCRIPTION
Inserted entries shouldn't be considered as unmapped

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>