### PR TITLE
Parallel eviction fixes

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -404,6 +404,7 @@ static void ocf_engine_map(struct ocf_request *req)
 
 	if (ocf_engine_unmapped_count(req) >
 			ocf_freelist_num_free(cache->freelist)) {
+		ocf_engine_lookup(req);
 		ocf_req_set_mapping_error(req);
 		return;
 	}

--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -203,11 +203,16 @@ static void ocf_engine_set_hot(struct ocf_request *req)
 	uint8_t status;
 	unsigned i;
 
+	if (req->info.hit_no == 0 && req->info.invalid_no == 0) {
+		/* no previously mapped clines */
+		return;
+	}
+
 	for (i = 0; i < req->core_line_count; i++) {
 		entry = &(req->map[i]);
 		status = entry->status;
 
-		if (status == LOOKUP_HIT || status == LOOKUP_INSERTED) {
+		if (status == LOOKUP_HIT) {
 			/* Update eviction (LRU) */
 			ocf_eviction_set_hot_cache_line(cache, entry->coll_idx);
 		}
@@ -347,6 +352,7 @@ static void ocf_engine_map_cache_line(struct ocf_request *req,
 
 	/* Update LRU:: Move this node to head of lru list. */
 	ocf_eviction_init_cache_line(cache, cache_line);
+	ocf_eviction_set_hot_cache_line(cache, cache_line);
 }
 
 static void ocf_engine_map_hndl_error(struct ocf_cache *cache,

--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -402,9 +402,6 @@ static void ocf_engine_map(struct ocf_request *req)
 	uint64_t core_line;
 	ocf_core_id_t core_id = ocf_core_get_id(req->core);
 
-	if (!ocf_engine_unmapped_count(req))
-		return;
-
 	if (ocf_engine_unmapped_count(req) >
 			ocf_freelist_num_free(cache->freelist)) {
 		ocf_req_set_mapping_error(req);


### PR DESCRIPTION
This assures that cacheline with LOOKUP_INSERTED status
is always present on the LRU list.

This fixes an ENV_BUG() caused by an attempt to remove
a cacheline from LRU list which was not there. This
happened when cacheline was mapped from freelist
(LOOKUP_INSERTED) but the entire request mapping failed
and generic cleanup routines attempted to invalidate cacheline,
including removing it from the LRU list. As engine_set_hot()
is called after successfull mapping, the inserted cacheline was
not yet present on the LRU list.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>