### PR TITLE
ocf_request: Deallocate request with separately allocated map properly

### DIFF
--- a/src/ocf_request.c
+++ b/src/ocf_request.c
@@ -204,8 +204,10 @@ void ocf_req_put(struct ocf_request *req)
 	if (!req->d2c && req->io_queue != req->cache->mngt_queue)
 		ocf_refcnt_dec(&req->cache->refcnt.metadata);
 
-	if (!env_mpool_del(req->cache->owner->resources.req, req,
-				req->core_line_count)) {
+	if (req->map == req->__map) {
+		env_mpool_del(req->cache->owner->resources.req, req,
+				req->core_line_count);
+	} else {
 		env_free(req->map);
 		env_mpool_del(req->cache->owner->resources.req, req, 1);
 	}


### PR DESCRIPTION
When allocation of request with map fails, we fallback to allocating
request with no map, and then allocate map separately. During request
put we need to distinguish between those two cases in order to deallocate
request properly.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>