### PR TITLE
Fix freeing oversized discard requests

### DIFF
--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -166,6 +166,9 @@ struct ocf_request {
 	uint32_t core_line_count;
 	/*! Core line count */
 
+	uint32_t alloc_core_line_count;
+	/*! Number of core lines at time of request allocation */
+
 	int error;
 	/*!< This filed indicates an error for OCF request */
 


### PR DESCRIPTION
When issuing discard request over 512KiB OCF would trim this request and
overwrite req->core_line_count which would then cause this request to be
freed from wrong mpool.

This is fixed now by saving core_line_count that was set when allocating
this request that is never overwritten. This alloc_core_line_count is
then used to free the request from correct mpool.

Signed-off-by: Jan Musial <jan.musial@intel.com>