### PR TITLE
Always call LRU_set_hot() under hash bucket lock

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -607,8 +607,8 @@ int ocf_engine_prepare_clines(struct ocf_request *req)
 	mapped = ocf_engine_is_mapped(req);
 	if (mapped) {
 		lock = lock_clines(req);
-		ocf_hb_req_prot_unlock_rd(req);
 		ocf_engine_set_hot(req);
+		ocf_hb_req_prot_unlock_rd(req);
 		return lock;
 	}
 
@@ -624,15 +624,14 @@ int ocf_engine_prepare_clines(struct ocf_request *req)
 	/* Mapping must be performed holding (at least) hash-bucket write lock */
 	ocf_hb_req_prot_lock_upgrade(req);
 	result = ocf_prepare_clines_miss(req);
+	if (!ocf_req_test_mapping_error(req))
+		ocf_engine_set_hot(req);
 	ocf_hb_req_prot_unlock_wr(req);
 
 	if (ocf_req_test_clean_eviction(req)) {
 		ocf_eviction_flush_dirty(req->cache, part, req->io_queue,
 				128);
 	}
-
-	if (!ocf_req_test_mapping_error(req))
-		ocf_engine_set_hot(req);
 
 	return result;
 }


### PR DESCRIPTION
set_hot() depends on cacheline metadata status to determine
on which list the element is located (dirty cs clean list).
Thus at least hash bucket lock is required when calling
set_hot().

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>