### PR TITLE
Clear hot flag when removing node from LRU list

### DIFF
--- a/src/eviction/lru.c
+++ b/src/eviction/lru.c
@@ -170,6 +170,7 @@ static void remove_lru_list(ocf_cache_t cache,
 		node->prev = end_marker;
 	}
 
+	node->hot = false;
 	--list->num_nodes;
 }
 


### PR DESCRIPTION
This isn't strictly required in current implementation as
nodes are always re-initialized before inserting to LRU list.
However it seems to make sense to zero the flag anyway to
make the code easier to reason about.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>