### PR TITLE
Remove early return from engine_map()

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -402,15 +402,6 @@ static void ocf_engine_map(struct ocf_request *req)
 	uint64_t core_line;
 	ocf_core_id_t core_id = ocf_core_get_id(req->core);
 
-	/* NOTE: request not refreshed after upgrading hash bucket lock.
-	 * ocf_engine_unmapped_count() is potentially not accurate. */
-	if (ocf_engine_unmapped_count(req) >
-			ocf_freelist_num_free(cache->freelist)) {
-		ocf_engine_lookup(req);
-		ocf_req_set_mapping_error(req);
-		return;
-	}
-
 	ocf_req_clear_info(req);
 
 	OCF_DEBUG_TRACE(req->cache);


### PR DESCRIPTION
Removing conditional early return from engine_map() function
in case of insufficient free cachelines. The reasons are:

1. current implementation does not treat unssufficient free
cachelines condition as an error,
2. the check is based on stale request info, so it is inaccurate,
3. it is easier to hit more paths with functional tests,
4. partially mapping request from the freelist becomes more common
rather than being a corner case dependent on racy timings between
threads

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>