### PR TITLE
Remove dirty check from LRU cleaner getter callback

### DIFF
--- a/src/eviction/lru.c
+++ b/src/eviction/lru.c
@@ -525,7 +525,6 @@ static int evp_lru_clean_get(ocf_cache_t cache, void *getter_context,
 	if (ctx->cline[idx] == end_marker)
 		return -1;
 
-	ENV_BUG_ON(!metadata_test_dirty(ctx->cache, ctx->cline[idx]));
 	*line = ctx->cline[idx];
 
 	return 0;


### PR DESCRIPTION
This check is incorrect as cacheline status may change
from dirty to clean at any point during cleaning, except for
when the hash bucket is locked.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>