### PR TITLE
Fix removing cores from cleaning policy

### DIFF
--- a/src/cleaning/acp.c
+++ b/src/cleaning/acp.c
@@ -666,6 +666,7 @@ void cleaning_policy_acp_remove_core(ocf_cache_t cache,
 	uint64_t i;
 
 	ENV_BUG_ON(acp->chunks_total < acp->num_chunks[core_id]);
+	ENV_BUG_ON(!acp->chunk_info[core_id]);
 
 	if (acp->state.in_progress && acp->state.chunk->core_id == core_id) {
 		acp->state.in_progress = false;

--- a/src/mngt/ocf_mngt_common.c
+++ b/src/mngt/ocf_mngt_common.c
@@ -41,11 +41,9 @@ void cache_mngt_core_remove_from_cleaning_pol(ocf_core_t core)
 	ocf_metadata_start_exclusive_access(&cache->metadata.lock);
 
 	clean_pol_type = cache->conf_meta->cleaning_policy_type;
-	if (cache->core[core_id].opened) {
-		if (cleaning_policy_ops[clean_pol_type].remove_core) {
-			cleaning_policy_ops[clean_pol_type].
-				remove_core(cache, core_id);
-		}
+	if (cleaning_policy_ops[clean_pol_type].remove_core) {
+		cleaning_policy_ops[clean_pol_type].
+			remove_core(cache, core_id);
 	}
 
 	ocf_metadata_end_exclusive_access(&cache->metadata.lock);


### PR DESCRIPTION
After detaching a core if user wanted to remove inactive cores the
cleaning policy data would not be initialized and would bug-out on next
core add.

This check was incorrect, as cleaning policy core metadata lifetime is
not bound to core volume being open or not.

Signed-off-by: Jan Musial <jan.musial@intel.com>