### PR TITLE
[experimental] Over-allocate metadata segments to avoid invalid memory access while flushing

### DIFF
--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -258,7 +258,7 @@ static int ocf_metadata_calculate_metadata_size(
 
 			/* Update offset for next container */
 			count_pages += ocf_metadata_raw_size_on_ssd(raw);
-			ram_footprint += (raw->entry_size * raw->entries);
+			ram_footprint += (raw->entry_size * raw->entries) + PAGE_SIZE;
 		}
 
 		/*
@@ -531,7 +531,7 @@ static struct ocf_metadata_ctrl *ocf_metadata_ctrl_init(
 			/* Update offset for next container */
 			page += ocf_metadata_raw_size_on_ssd(raw);
 
-			ram_footprint += (raw->entry_size * raw->entries);
+			ram_footprint += (raw->entry_size * raw->entries) + PAGE_SIZE;
 		}
 	}
 

--- a/src/metadata/metadata_raw_persistent.c
+++ b/src/metadata/metadata_raw_persistent.c
@@ -51,6 +51,7 @@ int raw_persistent_init(ocf_cache_t cache,
 	/* Allocate memory pool for entries */
 	mem_pool_size = raw->entries;
 	mem_pool_size *= raw->entry_size;
+	mem_pool_size += PAGE_SIZE;
 	raw->mem_pool_limit = mem_pool_size;
 	raw->mem_pool = ctx_persistent_meta_alloc(cache->owner, raw->persistent_allocator,
 			mem_pool_size, raw->metadata_segment, &ctx->loaded);


### PR DESCRIPTION

Signed-off-by: Jan Musial <jan.musial@intel.com>