### PR TITLE
Add priv field initialization on cache start

### DIFF
--- a/example/simple/src/main.c
+++ b/example/simple/src/main.c
@@ -126,7 +126,7 @@ int initialize_cache(ocf_ctx_t ctx, ocf_cache_t *cache)
 		return -ENOMEM;
 
 	/* Start cache */
-	ret = ocf_mngt_cache_start(ctx, cache, &cache_cfg);
+	ret = ocf_mngt_cache_start(ctx, cache, &cache_cfg, NULL);
 	if (ret)
 		goto err_priv;
 

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -325,12 +325,13 @@ static inline void ocf_mngt_cache_config_set_default(
  * @param[in] ctx OCF context
  * @param[out] cache Cache handle
  * @param[in] cfg Starting cache configuration
+ * @param[in] priv initial value of priv field in cache
  *
  * @retval 0 Cache started successfully
  * @retval Non-zero Error occurred and starting cache failed
  */
 int ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
-		struct ocf_mngt_cache_config *cfg);
+		struct ocf_mngt_cache_config *cfg, void *priv);
 
 /**
  * @brief Set queue to be used during management operations

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -1179,7 +1179,7 @@ static void _ocf_mngt_cache_init(ocf_cache_t cache,
 }
 
 static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
-		struct ocf_mngt_cache_config *cfg)
+		struct ocf_mngt_cache_config *cfg, void *priv)
 {
 	struct ocf_cache_mngt_init_params params;
 	ocf_cache_t tmp_cache;
@@ -1208,6 +1208,7 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 
 	tmp_cache = params.cache;
 	tmp_cache->owner = ctx;
+	tmp_cache->priv = priv;
 
 	/*
 	 * Initialize metadata selected segments of metadata in memory
@@ -1946,7 +1947,7 @@ static const char *_ocf_cache_mode_get_name(ocf_cache_mode_t cache_mode)
 }
 
 int ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
-		struct ocf_mngt_cache_config *cfg)
+		struct ocf_mngt_cache_config *cfg, void *priv)
 {
 	int result;
 
@@ -1957,7 +1958,7 @@ int ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 	if (result)
 		return result;
 
-	result = _ocf_mngt_cache_start(ctx, cache, cfg);
+	result = _ocf_mngt_cache_start(ctx, cache, cfg, priv);
 	if (!result) {
 		_ocf_mngt_cache_set_valid(*cache);
 

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -205,7 +205,7 @@ class Cache:
 
     def start_cache(self, default_io_queue: Queue = None, mngt_queue: Queue = None):
         status = self.owner.lib.ocf_mngt_cache_start(
-            self.owner.ctx_handle, byref(self.cache_handle), byref(self.cfg)
+            self.owner.ctx_handle, byref(self.cache_handle), byref(self.cfg), None
         )
         if status:
             raise OcfError("Creating cache instance failed", status)

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -394,7 +394,7 @@ def test_start_stop_noqueue(pyocf_ctx):
 
     cache_handle = c_void_p()
     status = pyocf_ctx.lib.ocf_mngt_cache_start(
-        pyocf_ctx.ctx_handle, byref(cache_handle), byref(_cache.cfg)
+        pyocf_ctx.ctx_handle, byref(cache_handle), byref(_cache.cfg), None
     )
     assert not status, "Failed to start cache: {}".format(status)
 


### PR DESCRIPTION
This allows access to it in ctx_metadata_updater_init, which is
done in the same call stack during initalization.

Signed-off-by: Kozlowski Mateusz <mateusz.kozlowski@intel.com>