### PR TITLE
Implement new metadata storage method

### DIFF
--- a/example/simple/src/main.c
+++ b/example/simple/src/main.c
@@ -107,7 +107,7 @@ int initialize_cache(ocf_ctx_t ctx, ocf_cache_t *cache)
 
 	/* Cache configuration */
 	ocf_mngt_cache_config_set_default(&cache_cfg);
-	cache_cfg.metadata_volatile = true;
+	cache_cfg.persistence_mode = ocf_metadata_persistence_ram;
 
 	/* Cache deivce (volume) configuration */
 	ocf_mngt_cache_device_config_set_default(&device_cfg);

--- a/inc/ocf_ctx.h
+++ b/inc/ocf_ctx.h
@@ -194,6 +194,17 @@ struct ocf_metadata_updater_ops {
 	void (*stop)(ocf_metadata_updater_t mu);
 };
 
+typedef struct ocf_persistent_meta_zone *ocf_persistent_meta_zone_t;
+
+struct ocf_persistent_metadata_ops {
+	ocf_persistent_meta_zone_t (*init)(ocf_cache_t cache, size_t size,
+			bool *load);
+	int (*deinit)(ocf_persistent_meta_zone_t zone);
+	void *(*alloc)(ocf_persistent_meta_zone_t zone, size_t size,
+			int alloc_id, bool *load);
+	int (*free)(ocf_persistent_meta_zone_t zone, int alloc_id, void *ptr);
+};
+
 /**
  * @brief OCF context specific operation
  */
@@ -209,6 +220,8 @@ struct ocf_ctx_ops {
 
 	/* Logger operations */
 	struct ocf_logger_ops logger;
+
+	struct ocf_persistent_metadata_ops persistent_meta;
 };
 
 struct ocf_ctx_config {

--- a/inc/ocf_def.h
+++ b/inc/ocf_def.h
@@ -303,6 +303,17 @@ typedef enum {
 } ocf_metadata_layout_t;
 
 /**
+ * @brief Metadata persistence mode
+ */
+typedef enum {
+	ocf_metadata_persistence_volume = 0,
+	ocf_metadata_persistence_ram,
+	ocf_metadata_persistence_persistent,
+	ocf_metadata_persistence_max,
+	ocf_metadata_persistence_default = ocf_metadata_persistence_volume,
+} ocf_metadata_persistence_mode_t;
+
+/**
  * @name OCF IO class definitions
  */
 /**

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -266,7 +266,7 @@ struct ocf_mngt_cache_config {
 	 */
 	ocf_metadata_layout_t metadata_layout;
 
-	bool metadata_volatile;
+	ocf_metadata_persistence_mode_t persistence_mode;
 
 	/**
 	 * @brief Backfill configuration
@@ -311,7 +311,7 @@ static inline void ocf_mngt_cache_config_set_default(
 	cfg->promotion_policy = ocf_promotion_default;
 	cfg->cache_line_size = ocf_cache_line_size_4;
 	cfg->metadata_layout = ocf_metadata_layout_default;
-	cfg->metadata_volatile = false;
+	cfg->persistence_mode = ocf_metadata_persistence_default;
 	cfg->backfill.max_queue_size = 65536;
 	cfg->backfill.queue_unblock_size = 60000;
 	cfg->locked = false;

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -128,7 +128,7 @@ static void _ocf_discard_finish_step(struct ocf_request *req)
 
 	if (req->discard.handled < req->discard.nr_sects)
 		req->io_if = &_io_if_discard_step;
-	else if (!req->cache->metadata.is_volatile)
+	else if (req->cache->metadata.persistence_mode != ocf_metadata_persistence_ram)
 		req->io_if = &_io_if_discard_flush_cache;
 	else
 		req->io_if = &_io_if_discard_core;

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -410,6 +410,12 @@ void ocf_metadata_deinit_variable_size(struct ocf_cache *cache)
 			i < metadata_segment_max; i++) {
 		ocf_metadata_segment_destroy(cache, ctrl->segment[i]);
 	}
+
+	if (ctrl->persistent_meta_variable) {
+		ctx_persistent_meta_deinit(cache->owner,
+				ctrl->persistent_meta_variable);
+		ctrl->persistent_meta_variable = NULL;
+	}
 }
 
 static inline void ocf_metadata_config_init(struct ocf_cache *cache,
@@ -448,6 +454,12 @@ static void ocf_metadata_deinit_fixed_size(struct ocf_cache *cache)
 
 	ocf_metadata_superblock_destroy(cache, superblock);
 
+	if (ctrl->persistent_meta_fixed) {
+		ctx_persistent_meta_deinit(cache->owner,
+				ctrl->persistent_meta_fixed);
+		ctrl->persistent_meta_fixed = NULL;
+	}
+
 	env_vfree(ctrl);
 	cache->metadata.priv = NULL;
 
@@ -456,48 +468,69 @@ static void ocf_metadata_deinit_fixed_size(struct ocf_cache *cache)
 }
 
 static struct ocf_metadata_ctrl *ocf_metadata_ctrl_init(
-		bool metadata_volatile)
+		ocf_metadata_persistence_mode_t persistence_mode)
 {
 	struct ocf_metadata_ctrl *ctrl = NULL;
 	uint32_t page = 0;
 	uint32_t i = 0;
+	enum ocf_metadata_raw_type default_raw_type;
+
+	switch (persistence_mode) {
+	case ocf_metadata_persistence_volume:
+		default_raw_type = metadata_raw_type_ram;
+		break;
+
+	case ocf_metadata_persistence_ram:
+		default_raw_type = metadata_raw_type_volatile;
+		break;
+
+	case ocf_metadata_persistence_persistent:
+		default_raw_type = metadata_raw_type_persistent;
+		break;
+
+	default:
+		ENV_BUG();
+		break;
+	}
 
 	ctrl = env_vzalloc(sizeof(*ctrl));
 	if (!ctrl)
 		return NULL;
 
 	/* Initial setup of RAW containers */
-	for (i = 0; i < metadata_segment_fixed_size_max; i++) {
+	for (i = 0; i < metadata_segment_max; i++) {
 		struct ocf_metadata_raw *raw = &ctrl->raw_desc[i];
 
 		raw->metadata_segment = i;
 
 		/* Default type for metadata RAW container */
-		raw->raw_type = metadata_raw_type_ram;
+		raw->raw_type = default_raw_type;
 
-		if (metadata_volatile) {
-			raw->raw_type = metadata_raw_type_volatile;
-		} else if (i == metadata_segment_core_uuid) {
+		if (i == metadata_segment_core_uuid &&
+			persistence_mode == ocf_metadata_persistence_volume) {
 			raw->raw_type = metadata_raw_type_dynamic;
 		}
 
-		/* Entry size configuration */
-		raw->entry_size
-			= ocf_metadata_get_element_size(i, NULL);
-		raw->entries_in_page = PAGE_SIZE / raw->entry_size;
+		/* We can only calculate sizes for fixed size metadata segments */
+		if (i < metadata_segment_fixed_size_max) {
+			/* Entry size configuration */
+			raw->entry_size
+				= ocf_metadata_get_element_size(i, NULL);
+			raw->entries_in_page = PAGE_SIZE / raw->entry_size;
 
-		/* Setup number of entries */
-		raw->entries = ocf_metadata_get_entries(i, 0);
+			/* Setup number of entries */
+			raw->entries = ocf_metadata_get_entries(i, 0);
 
-		/*
-		 * Setup SSD location and size
-		 */
-		raw->ssd_pages_offset = page;
-		raw->ssd_pages = OCF_DIV_ROUND_UP(raw->entries,
-				raw->entries_in_page);
+			/*
+			 * Setup SSD location and size
+			 */
+			raw->ssd_pages_offset = page;
+			raw->ssd_pages = OCF_DIV_ROUND_UP(raw->entries,
+					raw->entries_in_page);
 
-		/* Update offset for next container */
-		page += ocf_metadata_raw_size_on_ssd(raw);
+			/* Update offset for next container */
+			page += ocf_metadata_raw_size_on_ssd(raw);
+		}
 	}
 
 	ctrl->count_pages = page;
@@ -521,6 +554,8 @@ static int ocf_metadata_init_fixed_size(struct ocf_cache *cache,
 	ocf_core_id_t core_id;
 	uint32_t i = 0;
 	int result = 0;
+	bool loaded = false;
+	ocf_persistent_meta_zone_t persistent_meta;
 
 	OCF_DEBUG_TRACE(cache);
 
@@ -528,11 +563,25 @@ static int ocf_metadata_init_fixed_size(struct ocf_cache *cache,
 
 	ocf_metadata_config_init(cache, settings, cache_line_size);
 
-	ctrl = ocf_metadata_ctrl_init(metadata->is_volatile);
+	ctrl = ocf_metadata_ctrl_init(metadata->persistence_mode);
 	if (!ctrl)
 		return -OCF_ERR_NO_MEM;
 	metadata->priv = ctrl;
 
+	if (metadata->persistence_mode == ocf_metadata_persistence_persistent) {
+		persistent_meta = ctx_persistent_meta_init(cache->owner, cache,
+				ctrl->ram_footprint, &loaded);
+		if (!persistent_meta) {
+			ocf_metadata_deinit_fixed_size(cache);
+			return -OCF_ERR_NO_MEM;
+		}
+		ctrl->persistent_meta_fixed = persistent_meta;
+	}
+
+	cache->metadata.loaded = loaded;
+
+	ctrl->raw_desc[metadata_segment_sb_config].persistent_allocator =
+		ctrl->persistent_meta_fixed;
 	result = ocf_metadata_superblock_init(
 			&ctrl->segment[metadata_segment_sb_config], cache,
 			&ctrl->raw_desc[metadata_segment_sb_config]);
@@ -546,6 +595,8 @@ static int ocf_metadata_init_fixed_size(struct ocf_cache *cache,
 	for (i = 0; i < metadata_segment_fixed_size_max; i++) {
 		if (i == metadata_segment_sb_config)
 			continue;
+		ctrl->raw_desc[i].persistent_allocator =
+			ctrl->persistent_meta_fixed;
 		result |= ocf_metadata_segment_init(
 				&ctrl->segment[i],
 				cache,
@@ -610,7 +661,7 @@ static void ocf_metadata_init_layout(struct ocf_cache *cache,
 	ENV_BUG_ON(layout >= ocf_metadata_layout_max || layout < 0);
 
 	/* Initialize metadata location interface*/
-	if (cache->metadata.is_volatile)
+	if (cache->metadata.persistence_mode == ocf_metadata_persistence_ram)
 		layout = ocf_metadata_layout_seq;
 	cache->metadata.layout = layout;
 }
@@ -626,11 +677,15 @@ int ocf_metadata_init_variable_size(struct ocf_cache *cache,
 	uint32_t i = 0;
 	ocf_cache_line_t line;
 	struct ocf_metadata_ctrl *ctrl = NULL;
+	struct ocf_metadata *metadata = &cache->metadata;
 	struct ocf_cache_line_settings *settings =
-		(struct ocf_cache_line_settings *)&cache->metadata.settings;
+		(struct ocf_cache_line_settings *)&metadata->settings;
 	ocf_flush_page_synch_t lock_page, unlock_page;
 	uint64_t device_lines;
 	struct ocf_metadata_segment *superblock;
+	ocf_persistent_meta_zone_t persistent_meta;
+	ocf_cache_line_t old_pages;
+	bool loaded;
 
 	OCF_DEBUG_TRACE(cache);
 
@@ -663,27 +718,26 @@ int ocf_metadata_init_variable_size(struct ocf_cache *cache,
 			i < metadata_segment_max; i++) {
 		struct ocf_metadata_raw *raw = &ctrl->raw_desc[i];
 
-		raw->metadata_segment = i;
-
-		/* Default type for metadata RAW container */
-		raw->raw_type = metadata_raw_type_ram;
-
-		if (cache->metadata.is_volatile) {
-			raw->raw_type = metadata_raw_type_volatile;
-		} else if (i == metadata_segment_collision &&
-				ocf_volume_is_atomic(&cache->device->volume)) {
-			raw->raw_type = metadata_raw_type_atomic;
-		}
-
 		/* Entry size configuration */
 		raw->entry_size
 			= ocf_metadata_get_element_size(i, settings);
 		raw->entries_in_page = PAGE_SIZE / raw->entry_size;
 	}
 
+	old_pages = ctrl->count_pages;
+
 	if (0 != ocf_metadata_calculate_metadata_size(cache, ctrl,
 			settings)) {
 		return -1;
+	}
+
+	if (metadata->persistence_mode == ocf_metadata_persistence_persistent) {
+		persistent_meta = ctx_persistent_meta_init(cache->owner, cache,
+				(ctrl->count_pages - old_pages) * PAGE_SIZE,
+				&loaded);
+		if (!persistent_meta)
+			return -OCF_ERR_NO_MEM;
+		ctrl->persistent_meta_variable = persistent_meta;
 	}
 
 	OCF_DEBUG_PARAM(cache, "Metadata begin pages = %u", ctrl->start_page);
@@ -707,6 +761,8 @@ int ocf_metadata_init_variable_size(struct ocf_cache *cache,
 			lock_page = unlock_page = NULL;
 		}
 
+		ctrl->raw_desc[i].persistent_allocator =
+			ctrl->persistent_meta_variable;
 		result |= ocf_metadata_segment_init(
 				&ctrl->segment[i],
 				cache,
@@ -1599,15 +1655,19 @@ bool ocf_metadata_##what(struct ocf_cache *cache, \
 	_ocf_metadata_funcs_5arg(test_and_set_##what) \
 	_ocf_metadata_funcs_5arg(test_and_clear_##what)
 
-_ocf_metadata_funcs(dirty)
-_ocf_metadata_funcs(valid)
+_ocf_metadata_funcs(dirty);
+_ocf_metadata_funcs(valid);
 
 int ocf_metadata_init(struct ocf_cache *cache,
-		ocf_cache_line_size_t cache_line_size)
+		ocf_cache_line_size_t cache_line_size,
+		ocf_metadata_persistence_mode_t persistence_mode)
 {
 	int ret;
+	ocf_persistent_meta_zone_t pmeta_zone;
 
 	OCF_DEBUG_TRACE(cache);
+
+	cache->metadata.persistence_mode = persistence_mode;
 
 	ret = ocf_metadata_init_fixed_size(cache, cache_line_size);
 	if (ret) {

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -1669,7 +1669,6 @@ int ocf_metadata_init(struct ocf_cache *cache,
 		ocf_metadata_persistence_mode_t persistence_mode)
 {
 	int ret;
-	ocf_persistent_meta_zone_t pmeta_zone;
 
 	OCF_DEBUG_TRACE(cache);
 

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -746,6 +746,12 @@ int ocf_metadata_init_variable_size(struct ocf_cache *cache,
 			return -OCF_ERR_NO_MEM;
 	}
 
+	if (loaded != cache->metadata.loaded) {
+		ocf_cache_log(cache, log_err, "Persistent metadata zones state "
+				"mismatch!");
+		return -OCF_ERR_INVAL;
+	}
+
 	OCF_DEBUG_PARAM(cache, "Metadata begin pages = %u", ctrl->start_page);
 	OCF_DEBUG_PARAM(cache, "Metadata count pages = %u", ctrl->count_pages);
 	OCF_DEBUG_PARAM(cache, "Metadata end pages = %u", ctrl->start_page

--- a/src/metadata/metadata.h
+++ b/src/metadata/metadata.h
@@ -29,10 +29,12 @@
  *
  * @param cache - Cache instance
  * @param cache_line_size Cache line size
+ * @param persistence_mode metadata persistence mode
  * @return 0 - Operation success otherwise failure
  */
 int ocf_metadata_init(struct ocf_cache *cache,
-		ocf_cache_line_size_t cache_line_size);
+		ocf_cache_line_size_t cache_line_size,
+		ocf_metadata_persistence_mode_t persistence_mode);
 
 /**
  * @brief Initialize per-cacheline metadata

--- a/src/metadata/metadata_internal.h
+++ b/src/metadata/metadata_internal.h
@@ -21,6 +21,7 @@ struct ocf_metadata_ctrl {
 	ocf_cache_line_t cachelines;
 	ocf_cache_line_t start_page;
 	ocf_cache_line_t count_pages;
+	uint64_t ram_footprint;
 	uint32_t device_lines;
 	size_t mapping_size;
 	struct ocf_metadata_raw raw_desc[metadata_segment_max];

--- a/src/metadata/metadata_internal.h
+++ b/src/metadata/metadata_internal.h
@@ -25,6 +25,8 @@ struct ocf_metadata_ctrl {
 	size_t mapping_size;
 	struct ocf_metadata_raw raw_desc[metadata_segment_max];
 	struct ocf_metadata_segment *segment[metadata_segment_max];
+	ocf_persistent_meta_zone_t persistent_meta_fixed;
+	ocf_persistent_meta_zone_t persistent_meta_variable;
 };
 
 struct ocf_metadata_context {

--- a/src/metadata/metadata_raw.c
+++ b/src/metadata/metadata_raw.c
@@ -8,6 +8,7 @@
 #include "metadata_raw.h"
 #include "metadata_io.h"
 #include "metadata_raw_atomic.h"
+#include "metadata_raw_persistent.h"
 #include "../ocf_def_priv.h"
 #include "../ocf_priv.h"
 
@@ -220,7 +221,7 @@ static void _raw_ram_load_all_complete(ocf_cache_t cache,
 /*
  * RAM Implementation - Load all metadata elements from SSD
  */
-static void _raw_ram_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
+void raw_ram_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
 		ocf_metadata_end_t cmpl, void *priv)
 {
 	struct _raw_ram_load_all_context *context;
@@ -547,7 +548,7 @@ static const struct raw_iface IRAW[metadata_raw_type_max] = {
 		.checksum		= _raw_ram_checksum,
 		.page			= _raw_ram_page,
 		.access			= _raw_ram_access,
-		.load_all		= _raw_ram_load_all,
+		.load_all		= raw_ram_load_all,
 		.flush_all		= _raw_ram_flush_all,
 		.flush_mark		= _raw_ram_flush_mark,
 		.flush_do_asynch	= _raw_ram_flush_do_asynch,
@@ -586,10 +587,23 @@ static const struct raw_iface IRAW[metadata_raw_type_max] = {
 		.checksum		= _raw_ram_checksum,
 		.page			= _raw_ram_page,
 		.access			= _raw_ram_access,
-		.load_all		= _raw_ram_load_all,
+		.load_all		= raw_ram_load_all,
 		.flush_all		= _raw_ram_flush_all,
 		.flush_mark		= raw_atomic_flush_mark,
 		.flush_do_asynch	= raw_atomic_flush_do_asynch,
+	},
+	[metadata_raw_type_persistent] = {
+		.init			= raw_persistent_init,
+		.deinit			= raw_persistent_deinit,
+		.size_of		= _raw_ram_size_of,
+		.size_on_ssd		= _raw_ram_size_on_ssd,
+		.checksum		= _raw_ram_checksum,
+		.page			= _raw_ram_page,
+		.access			= _raw_ram_access,
+		.load_all		= raw_persistent_load_all,
+		.flush_all		= _raw_ram_flush_all,
+		.flush_mark		= _raw_ram_flush_mark,
+		.flush_do_asynch	= _raw_ram_flush_do_asynch,
 	},
 };
 

--- a/src/metadata/metadata_raw.h
+++ b/src/metadata/metadata_raw.h
@@ -40,6 +40,8 @@ enum ocf_metadata_raw_type {
 	 */
 	metadata_raw_type_atomic,
 
+	metadata_raw_type_persistent,
+
 	metadata_raw_type_max, /*!<  MAX */
 	metadata_raw_type_min = metadata_raw_type_ram /*!<  MAX */
 };
@@ -83,6 +85,8 @@ struct ocf_metadata_raw {
 	void *mem_pool; /*!< Private memory pool*/
 
 	size_t mem_pool_limit; /*! Current memory pool size (limit) */
+
+	ocf_persistent_meta_zone_t persistent_allocator;
 
 	void *priv; /*!< Private data - context */
 
@@ -312,5 +316,8 @@ static inline void *ocf_metadata_raw_get_mem(struct ocf_metadata_raw *raw)
 {
 	return raw->mem_pool;
 }
+
+void raw_ram_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
+		ocf_metadata_end_t cmpl, void *priv);
 
 #endif /* METADATA_RAW_H_ */

--- a/src/metadata/metadata_raw_persistent.c
+++ b/src/metadata/metadata_raw_persistent.c
@@ -49,8 +49,8 @@ int raw_persistent_init(ocf_cache_t cache,
 	OCF_DEBUG_TRACE(cache);
 
 	/* Allocate memory pool for entries */
-	mem_pool_size = raw->ssd_pages;
-	mem_pool_size *= PAGE_SIZE;
+	mem_pool_size = raw->entries;
+	mem_pool_size *= raw->entry_size;
 	raw->mem_pool_limit = mem_pool_size;
 	raw->mem_pool = ctx_persistent_meta_alloc(cache->owner, raw->persistent_allocator,
 			mem_pool_size, raw->metadata_segment, &ctx->loaded);

--- a/src/metadata/metadata_raw_persistent.c
+++ b/src/metadata/metadata_raw_persistent.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright(c) 2021 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#include "metadata.h"
+#include "metadata_io.h"
+#include "metadata_segment_id.h"
+#include "metadata_raw.h"
+#include "metadata_raw_persistent.h"
+#include "../utils/utils_cache_line.h"
+#include "../ocf_def_priv.h"
+
+#define OCF_METADATA_RAW_PERSISTENT_DEBUG 0
+
+#if 1 == OCF_METADATA_RAW_PERSISTENT_DEBUG
+#define OCF_DEBUG_TRACE(cache) \
+	ocf_cache_log(cache, log_info, "[Metadata][Raw][Persistent] %s\n", __func__)
+
+#define OCF_DEBUG_MSG(cache, msg) \
+	ocf_cache_log(cache, log_info, "[Metadata][Raw][Persistent] %s - %s\n", \
+			__func__, msg)
+
+#define OCF_DEBUG_PARAM(cache, format, ...) \
+	ocf_cache_log(cache, log_info, "[Metadata][Raw][Persistent] %s - "format"\n", \
+			__func__, ##__VA_ARGS__)
+#else
+#define OCF_DEBUG_TRACE(cache)
+#define OCF_DEBUG_MSG(cache, msg)
+#define OCF_DEBUG_PARAM(cache, format, ...)
+#endif
+
+struct raw_persistent_ctx {
+	bool loaded;
+};
+int raw_persistent_init(ocf_cache_t cache,
+	ocf_flush_page_synch_t lock_page_pfn,
+	ocf_flush_page_synch_t unlock_page_pfn,
+	struct ocf_metadata_raw *raw)
+{
+	size_t mem_pool_size;
+	struct raw_persistent_ctx *ctx = env_vmalloc(sizeof(struct raw_persistent_ctx));
+
+	if (!ctx)
+		return -OCF_ERR_NO_MEM;
+
+	raw->priv = ctx;
+
+	OCF_DEBUG_TRACE(cache);
+
+	/* Allocate memory pool for entries */
+	mem_pool_size = raw->ssd_pages;
+	mem_pool_size *= PAGE_SIZE;
+	raw->mem_pool_limit = mem_pool_size;
+	raw->mem_pool = ctx_persistent_meta_alloc(cache->owner, raw->persistent_allocator,
+			mem_pool_size, raw->metadata_segment, &ctx->loaded);
+	if (!raw->mem_pool) {
+		env_vfree(ctx);
+		return -OCF_ERR_NO_MEM;
+	}
+
+	if (!ctx->loaded)
+		ENV_BUG_ON(env_memset(raw->mem_pool, mem_pool_size, 0));
+
+	raw->lock_page = lock_page_pfn;
+	raw->unlock_page = unlock_page_pfn;
+
+	return 0;
+}
+
+int raw_persistent_deinit(ocf_cache_t cache, struct ocf_metadata_raw *raw)
+{
+	int result;
+
+	result = ctx_persistent_meta_free(cache->owner, raw->persistent_allocator,
+			raw->metadata_segment, raw->mem_pool);
+	if (result)
+		return result;
+
+	env_vfree(raw->priv);
+
+	return 0;
+}
+
+void raw_persistent_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
+		ocf_metadata_end_t cmpl, void *priv)
+{
+	struct raw_persistent_ctx *ctx = raw->priv;
+
+	if (!ctx->loaded)
+		raw_ram_load_all(cache, raw, cmpl, priv);
+	else
+		cmpl(priv, 0);
+}
+

--- a/src/metadata/metadata_raw_persistent.h
+++ b/src/metadata/metadata_raw_persistent.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) 2012-2020 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef __METADATA_RAW_PERSISTENT_H__
+#define __METADATA_RAW_PERSISTENT_H__
+
+int raw_persistent_init(ocf_cache_t cache,
+		ocf_flush_page_synch_t lock_page_pfn,
+		ocf_flush_page_synch_t unlock_page_pfn,
+		struct ocf_metadata_raw *raw);
+
+int raw_persistent_deinit(ocf_cache_t cache, struct ocf_metadata_raw *raw);
+
+void raw_persistent_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
+		ocf_metadata_end_t cmpl, void *priv);
+
+#endif /* __METADATA_RAW_PERSISTENT_H__ */

--- a/src/metadata/metadata_structs.h
+++ b/src/metadata/metadata_structs.h
@@ -77,8 +77,10 @@ struct ocf_metadata {
 	const struct ocf_cache_line_settings settings;
 		/*!< Cache line configuration */
 
-	bool is_volatile;
-		/*!< true if metadata used in volatile mode (RAM only) */
+	ocf_metadata_persistence_mode_t persistence_mode;
+		/*!< mode of metadata persistence */
+
+	bool loaded;
 
 	struct ocf_metadata_lock lock;
 };

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -48,8 +48,6 @@ struct ocf_cache_mngt_init_params {
 	uint8_t locked;
 		/*!< Keep cache locked */
 
-	bool metadata_volatile;
-
 	/**
 	 * @brief initialization state (in case of error, it is used to know
 	 * which assets have to be deallocated in premature exit from function
@@ -142,6 +140,8 @@ struct ocf_cache_attach_context {
 
 		uint8_t dirty_flushed;
 		/*!< is dirty data fully flushed */
+
+		bool persistent_meta_loaded;
 	} metadata;
 
 	struct {
@@ -157,29 +157,6 @@ struct ocf_cache_attach_context {
 
 	ocf_pipeline_t pipeline;
 };
-
-static void __init_partitions(ocf_cache_t cache)
-{
-	ocf_part_id_t i_part;
-
-	/* Init default Partition */
-	ENV_BUG_ON(ocf_mngt_add_partition_to_cache(cache, PARTITION_DEFAULT,
-			"unclassified", 0, PARTITION_SIZE_MAX,
-			OCF_IO_CLASS_PRIO_LOWEST, true));
-
-	/* Add other partition to the cache and make it as dummy */
-	for (i_part = 0; i_part < OCF_IO_CLASS_MAX; i_part++) {
-		ocf_refcnt_freeze(&cache->user_parts[i_part].cleaning.counter);
-
-		if (i_part == PARTITION_DEFAULT)
-			continue;
-
-		/* Init default Partition */
-		ENV_BUG_ON(ocf_mngt_add_partition_to_cache(cache, i_part,
-				"Inactive", 0, PARTITION_SIZE_MAX,
-				OCF_IO_CLASS_PRIO_LOWEST, false));
-	}
-}
 
 static void __init_partitions_attached(ocf_cache_t cache)
 {
@@ -482,7 +459,8 @@ void _ocf_mngt_load_init_instance_complete(void *priv, int error)
 	if (!cleaning_policy_ops[cleaning_policy].initialize)
 		goto out;
 
-	if (context->metadata.shutdown_status == ocf_metadata_clean_shutdown)
+	if (context->metadata.shutdown_status == ocf_metadata_clean_shutdown ||
+			context->metadata.persistent_meta_loaded)
 		result = cleaning_policy_ops[cleaning_policy].initialize(cache, 0);
 	else
 		result = cleaning_policy_ops[cleaning_policy].initialize(cache, 1);
@@ -541,10 +519,15 @@ static void _ocf_mngt_load_init_instance(ocf_pipeline_t pipeline,
 	if (ret)
 		OCF_PL_FINISH_RET(pipeline, ret);
 
-	if (context->metadata.shutdown_status == ocf_metadata_clean_shutdown)
-		_ocf_mngt_load_init_instance_clean_load(context);
-	else
-		_ocf_mngt_load_init_instance_recovery(context);
+
+	if (!context->cache->metadata.loaded) {
+		if (context->metadata.shutdown_status == ocf_metadata_clean_shutdown)
+			_ocf_mngt_load_init_instance_clean_load(context);
+		else
+			_ocf_mngt_load_init_instance_recovery(context);
+	} else {
+		_ocf_mngt_load_init_instance_complete(context, 0);
+	}
 }
 
 /**
@@ -685,7 +668,6 @@ static int _ocf_mngt_init_prepare_cache(struct ocf_cache_mngt_init_params *param
 	cache->use_submit_io_fast = cfg->use_submit_io_fast;
 
 	cache->eviction_policy_init = cfg->eviction_policy;
-	cache->metadata.is_volatile = cfg->metadata_volatile;
 
 out:
 	return ret;
@@ -984,6 +966,8 @@ static void _ocf_mngt_attach_prepare_metadata(ocf_pipeline_t pipeline,
 	context->metadata.line_size = context->metadata.line_size ?:
 			cache->metadata.settings.size;
 
+	context->metadata.persistent_meta_loaded = cache->metadata.loaded;
+
 	/*
 	 * Initialize variable size metadata segments
 	 */
@@ -1168,14 +1152,8 @@ static void _ocf_mngt_cache_init(ocf_cache_t cache,
 	cache->conf_meta->metadata_layout = params->metadata.layout;
 	cache->conf_meta->promotion_policy_type = params->metadata.promotion_policy;
 
-	INIT_LIST_HEAD(&cache->io_queues);
-
-	/* Init Partitions */
-	ocf_part_init(cache);
-
 	__init_cores(cache);
 	__init_metadata_version(cache);
-	__init_partitions(cache);
 }
 
 static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
@@ -1191,7 +1169,6 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 	params.metadata.cache_mode = cfg->cache_mode;
 	params.metadata.layout = cfg->metadata_layout;
 	params.metadata.line_size = cfg->cache_line_size;
-	params.metadata_volatile = cfg->metadata_volatile;
 	params.metadata.promotion_policy = cfg->promotion_policy;
 	params.locked = cfg->locked;
 
@@ -1213,7 +1190,8 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 	/*
 	 * Initialize metadata selected segments of metadata in memory
 	 */
-	result = ocf_metadata_init(tmp_cache, params.metadata.line_size);
+	result = ocf_metadata_init(tmp_cache, cfg->cache_line_size,
+			cfg->persistence_mode);
 	if (result) {
 		env_rmutex_unlock(&ctx->lock);
 		result =  -OCF_ERR_NO_MEM;
@@ -1237,7 +1215,16 @@ static int _ocf_mngt_cache_start(ocf_ctx_t ctx, ocf_cache_t *cache,
 
 	ocf_cache_log(tmp_cache, log_debug, "Metadata initialized\n");
 
-	_ocf_mngt_cache_init(tmp_cache, &params);
+	INIT_LIST_HEAD(&tmp_cache->io_queues);
+
+	/* Init Partitions */
+
+	if (!tmp_cache->metadata.loaded) {
+		ocf_part_init(tmp_cache);
+		_ocf_mngt_cache_init(tmp_cache, &params);
+	} else {
+		ocf_part_load(tmp_cache);
+	}
 
 	ocf_ctx_get(ctx);
 
@@ -1422,6 +1409,10 @@ static void _ocf_mngt_attach_flush_metadata(ocf_pipeline_t pipeline,
 	struct ocf_cache_attach_context *context = priv;
 	ocf_cache_t cache = context->cache;
 
+	if (context->metadata.persistent_meta_loaded) {
+		ocf_pipeline_next(context->pipeline);
+		return;
+	}
 	ocf_metadata_flush_all(cache,
 			_ocf_mngt_attach_flush_metadata_complete, context);
 }
@@ -1907,6 +1898,11 @@ static int _ocf_mngt_cache_validate_cfg(struct ocf_mngt_cache_config *cfg)
 		return -OCF_ERR_INVAL;
 	}
 
+	if (cfg->persistence_mode >= ocf_metadata_persistence_max ||
+			cfg->persistence_mode < 0) {
+		return -OCF_ERR_INVAL;
+	}
+
 	if (cfg->backfill.queue_unblock_size > cfg->backfill.max_queue_size )
 		return -OCF_ERR_INVAL;
 
@@ -2139,7 +2135,7 @@ void ocf_mngt_cache_load(ocf_cache_t cache,
 		OCF_CMPL_RET(cache, priv, -OCF_ERR_INVAL);
 
 	/* Load is not allowed in volatile metadata mode */
-	if (cache->metadata.is_volatile)
+	if (cache->metadata.persistence_mode == ocf_metadata_persistence_ram)
 		OCF_CMPL_RET(cache, priv, -OCF_ERR_INVAL);
 
 	/* Load is not allowed with 'force' flag on */

--- a/src/mngt/ocf_mngt_common.h
+++ b/src/mngt/ocf_mngt_common.h
@@ -23,7 +23,7 @@ int cache_mngt_thread_io_requests(void *data);
 
 int ocf_mngt_add_partition_to_cache(struct ocf_cache *cache,
 		ocf_part_id_t part_id, const char *name, uint32_t min_size,
-		uint32_t max_size, uint8_t priority, bool valid);
+		uint32_t max_size, uint8_t priority, bool valid, bool load);
 
 int ocf_mngt_cache_lock_init(ocf_cache_t cache);
 void ocf_mngt_cache_lock_deinit(ocf_cache_t cache);

--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -357,8 +357,6 @@ static void _ocf_mngt_cache_add_core_flush_sb_complete(void *priv, int error)
 	if (error)
 		OCF_PL_FINISH_RET(context->pipeline, -OCF_ERR_WRITE_CACHE);
 
-	/* Increase value of added cores */
-	context->cache->conf_meta->core_count++;
 
 	ocf_pipeline_next(context->pipeline);
 }
@@ -466,6 +464,7 @@ static void ocf_mngt_cache_add_core_insert(ocf_pipeline_t pipeline,
 
 	/* In metadata mark data this core was added into cache */
 	env_bit_set(core_id, cache->conf_meta->valid_core_bitmap);
+	context->cache->conf_meta->core_count++;
 	core->conf_meta->valid = true;
 	core->added = true;
 	core->opened = true;

--- a/src/mngt/ocf_mngt_io_class.c
+++ b/src/mngt/ocf_mngt_io_class.c
@@ -28,7 +28,7 @@ static uint64_t _ocf_mngt_count_parts_min_size(struct ocf_cache *cache)
 
 int ocf_mngt_add_partition_to_cache(struct ocf_cache *cache,
 		ocf_part_id_t part_id, const char *name, uint32_t min_size,
-		uint32_t max_size, uint8_t priority, bool valid)
+		uint32_t max_size, uint8_t priority, bool valid, bool load)
 {
 	uint32_t size;
 	struct ocf_lst_entry *iter;
@@ -40,7 +40,7 @@ int ocf_mngt_add_partition_to_cache(struct ocf_cache *cache,
 	if (part_id >= OCF_IO_CLASS_MAX)
 		return -OCF_ERR_INVAL;
 
-	if (cache->user_parts[part_id].config->flags.valid)
+	if (cache->user_parts[part_id].config->flags.valid && !load)
 		return -OCF_ERR_INVAL;
 
 	if (min_size > max_size)

--- a/src/ocf_ctx_priv.h
+++ b/src/ocf_ctx_priv.h
@@ -54,6 +54,29 @@ int ocf_ctx_register_volume_type_extended(ocf_ctx_t ctx, uint8_t type_id,
 		const struct ocf_volume_properties *properties,
 		const struct ocf_volume_extended *extended);
 
+static inline ocf_persistent_meta_zone_t ctx_persistent_meta_init(ocf_ctx_t ctx,
+		ocf_cache_t cache, size_t size, bool *loaded)
+{
+	return ctx->ops->persistent_meta.init(cache, size, loaded);
+}
+
+static inline int ctx_persistent_meta_deinit(ocf_ctx_t ctx,
+		ocf_persistent_meta_zone_t zone)
+{
+	return ctx->ops->persistent_meta.deinit(zone);
+}
+
+static inline void *ctx_persistent_meta_alloc(ocf_ctx_t ctx,
+		ocf_persistent_meta_zone_t zone, size_t size, int alloc_id, bool *load)
+{
+	return ctx->ops->persistent_meta.alloc(zone, size, alloc_id, load);
+}
+
+static inline int ctx_persistent_meta_free(ocf_ctx_t ctx,
+		ocf_persistent_meta_zone_t zone, int alloc_id, void *ptr)
+{
+	return ctx->ops->persistent_meta.free(zone, alloc_id, ptr);
+}
 /**
  * @name Environment data buffer operations wrappers
  * @{

--- a/src/utils/utils_part.h
+++ b/src/utils/utils_part.h
@@ -13,6 +13,8 @@
 
 void ocf_part_init(struct ocf_cache *cache);
 
+void ocf_part_load(struct ocf_cache *cache);
+
 static inline bool ocf_part_is_valid(struct ocf_user_part *part)
 {
 	return !!part->config->flags.valid;

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -52,7 +52,7 @@ class CacheConfig(Structure):
         ("_promotion_policy", c_uint32),
         ("_cache_line_size", c_uint64),
         ("_metadata_layout", c_uint32),
-        ("_metadata_volatile", c_bool),
+        ("_persistence_mode", c_uint32),
         ("_backfill", Backfill),
         ("_locked", c_bool),
         ("_pt_unaligned_io", c_bool),

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -363,7 +363,7 @@ class Cache:
         _name = name.encode("ascii")
 
         status = self.owner.lib.ocf_mngt_add_partition_to_cache(
-            self.cache_handle, part_id, _name, min_size, max_size, priority, valid
+            self.cache_handle, part_id, _name, min_size, max_size, priority, valid, False
         )
 
         self.write_unlock()
@@ -749,6 +749,7 @@ lib.ocf_mngt_add_partition_to_cache.argtypes = [
     c_uint32,
     c_uint32,
     c_uint8,
+    c_bool,
     c_bool,
 ]
 lib.ocf_mngt_cache_io_classes_configure.restype = c_int

--- a/tests/functional/pyocf/types/ctx.py
+++ b/tests/functional/pyocf/types/ctx.py
@@ -13,6 +13,7 @@ from .shared import OcfError
 from ..ocf import OcfLib
 from .queue import Queue
 from .volume import Volume
+from .persistent_metadata import PersistentMetaOps
 
 
 class OcfCtxOps(Structure):
@@ -21,6 +22,7 @@ class OcfCtxOps(Structure):
         ("cleaner", CleanerOps),
         ("metadata_updater", MetadataUpdaterOps),
         ("logger", LoggerOps),
+        ("persistent_meta", PersistentMetaOps),
     ]
 
 

--- a/tests/functional/pyocf/types/persistent_metadata.py
+++ b/tests/functional/pyocf/types/persistent_metadata.py
@@ -1,0 +1,19 @@
+#
+# Copyright(c) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+from ctypes import c_void_p, Structure, c_int, c_size_t, c_bool, POINTER, CFUNCTYPE
+
+
+class PersistentMetaOps(Structure):
+    INIT = CFUNCTYPE(c_void_p, c_void_p, c_size_t, POINTER(c_bool))
+    DEINIT = CFUNCTYPE(c_int, c_void_p)
+    ALLOC = CFUNCTYPE(c_void_p, c_void_p, c_size_t, c_int, POINTER(c_bool))
+    FREE = CFUNCTYPE(c_int, c_void_p, c_int, c_void_p)
+    _fields_ = [
+        ("_init", INIT),
+        ("_deinit", DEINIT),
+        ("_alloc", ALLOC),
+        ("_free", FREE),
+    ]


### PR DESCRIPTION
New metadata container enables the adapter to implement metadata memory pools which can outlive the OCF instance. This way whenever we load we can speed up the process by directly reattaching those memory pools instead of costly recovery procedure.

This is not yet production ready as the current metadata implementation is not transactional and reinstating memory pools after drity shutdown will not yield an usable cache instance.