### PR TITLE
Check for hit after upgrading hash bucket lock

### DIFF
--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -615,6 +615,13 @@ int ocf_engine_prepare_clines(struct ocf_request *req)
 
 	/* Mapping must be performed holding (at least) hash-bucket write lock */
 	ocf_hb_req_prot_lock_upgrade(req);
+	if (unlikely(ocf_engine_is_mapped(req))) {
+		lock = lock_clines(req);
+		ocf_engine_set_hot(req);
+		ocf_hb_req_prot_unlock_wr(req);
+		return lock;
+	}
+
 	result = ocf_prepare_clines_miss(req);
 	if (!ocf_req_test_mapping_error(req))
 		ocf_engine_set_hot(req);


### PR DESCRIPTION
Lookup is repeated after request is identified as miss and hash bucket
lock is upgraded (in order to map missing cachelines). At this point
cachelines status might change and the request might turn out to be
a hit after all. Adding check for this condition removes unnecessary
calls to remap logic.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>