### PR TITLE
Make loading in pyocf viable

### DIFF
--- a/inc/ocf_volume.h
+++ b/inc/ocf_volume.h
@@ -14,6 +14,7 @@
 #include "ocf_types.h"
 #include "ocf_env_headers.h"
 #include "ocf/ocf_err.h"
+#include "ocf/ocf_io.h"
 
 struct ocf_io;
 

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -570,7 +570,7 @@ class Cache:
     def write_unlock(self):
         self.owner.lib.ocf_mngt_cache_unlock(self.cache_handle)
 
-    def add_core(self, core: Core):
+    def add_core(self, core: Core, try_add=False):
         self.write_lock()
 
         c = OcfCompletion(
@@ -582,8 +582,11 @@ class Cache:
             ]
         )
 
+        cfg = core.get_cfg()
+        cfg._try_add = try_add
+
         self.owner.lib.ocf_mngt_cache_add_core(
-            self.cache_handle, byref(core.get_cfg()), c, None
+            self.cache_handle, byref(cfg), c, None
         )
 
         c.wait()

--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -19,9 +19,6 @@ from ctypes import (
     cast,
     byref,
     create_string_buffer,
-    sizeof,
-    memmove,
-    pointer,
 )
 from datetime import timedelta
 
@@ -68,23 +65,11 @@ class Core:
     ):
         self.cache = None
         self.device = device
-        self.device_name = device.uuid
+        self.name = name
+        self.seq_cutoff_threshold = seq_cutoff_threshold
+        self.seq_cutoff_promotion_count = seq_cutoff_promotion_count
+
         self.handle = c_void_p()
-        self.cfg = CoreConfig(
-            _uuid=Uuid(
-                _data=cast(
-                    create_string_buffer(self.device_name.encode("ascii")),
-                    c_char_p,
-                ),
-                _size=len(self.device_name) + 1,
-            ),
-            _name=name.encode("ascii"),
-            _volume_type=self.device.type_id,
-            _try_add=try_add,
-            _seq_cutoff_threshold=seq_cutoff_threshold,
-            _seq_cutoff_promotion_count=seq_cutoff_promotion_count,
-            _user_metadata=UserMetadata(_data=None, _size=0),
-        )
 
     @classmethod
     def using_device(cls, device, **kwargs):
@@ -92,11 +77,24 @@ class Core:
 
         return c
 
-    def get_cfg(self):
-        config_copy = CoreConfig()
-        memmove(pointer(config_copy), pointer(self.cfg), sizeof(config_copy))
+    def get_config(self):
+        cfg = CoreConfig(
+            _uuid=Uuid(
+                _data=cast(
+                    create_string_buffer(self.device.uuid.encode("ascii")),
+                    c_char_p,
+                ),
+                _size=len(self.device.uuid) + 1,
+            ),
+            _name=self.name.encode("ascii"),
+            _volume_type=self.device.type_id,
+            _try_add=False,
+            _seq_cutoff_threshold=self.seq_cutoff_threshold,
+            _seq_cutoff_promotion_count=self.seq_cutoff_promotion_count,
+            _user_metadata=UserMetadata(_data=None, _size=0),
+        )
 
-        return config_copy
+        return cfg
 
     def get_handle(self):
         return self.handle

--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -19,6 +19,9 @@ from ctypes import (
     cast,
     byref,
     create_string_buffer,
+    sizeof,
+    memmove,
+    pointer,
 )
 from datetime import timedelta
 
@@ -90,7 +93,10 @@ class Core:
         return c
 
     def get_cfg(self):
-        return self.cfg
+        config_copy = CoreConfig()
+        memmove(pointer(config_copy), pointer(self.cfg), sizeof(config_copy))
+
+        return config_copy
 
     def get_handle(self):
         return self.handle

--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -19,6 +19,7 @@ from ctypes import (
     cast,
     byref,
     create_string_buffer,
+    POINTER,
 )
 from datetime import timedelta
 
@@ -58,7 +59,6 @@ class Core:
     def __init__(
         self,
         device: Volume,
-        try_add: bool,
         name: str = "core",
         seq_cutoff_threshold: int = DEFAULT_SEQ_CUTOFF_THRESHOLD,
         seq_cutoff_promotion_count: int = DEFAULT_SEQ_CUTOFF_PROMOTION_COUNT,
@@ -73,7 +73,7 @@ class Core:
 
     @classmethod
     def using_device(cls, device, **kwargs):
-        c = cls(device=device, try_add=False, **kwargs)
+        c = cls(device=device, **kwargs)
 
         return c
 
@@ -222,6 +222,8 @@ class Core:
 
 
 lib = OcfLib.getInstance()
+lib.ocf_core_get_uuid_wrapper.restype = POINTER(Uuid)
+lib.ocf_core_get_uuid_wrapper.argtypes = [c_void_p]
 lib.ocf_core_get_volume.restype = c_void_p
 lib.ocf_volume_new_io.argtypes = [
     c_void_p,

--- a/tests/functional/pyocf/wrappers/ocf_mngt_wrappers.c
+++ b/tests/functional/pyocf/wrappers/ocf_mngt_wrappers.c
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright(c) 2022 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "ocf/ocf_mngt.h"
+
+void ocf_mngt_cache_config_set_default_wrapper(struct ocf_mngt_cache_config *cfg)
+{
+	ocf_mngt_cache_config_set_default(cfg);
+}

--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -92,7 +92,7 @@ def test_load_cache_with_cores(pyocf_ctx, open_cores):
     core_device = Volume(S.from_MiB(40))
 
     cache = Cache.start_on_device(cache_device)
-    core = Core.using_device(core_device)
+    core = Core.using_device(core_device, name="test_core")
 
     cache.add_core(core)
 
@@ -111,6 +111,8 @@ def test_load_cache_with_cores(pyocf_ctx, open_cores):
     cache = Cache.load_from_device(cache_device, open_cores=open_cores)
     if not open_cores:
         cache.add_core(core, try_add=True)
+    else:
+        core = cache.get_core_by_name("test_core")
 
     read_data = Data(write_data.size)
     io = core.new_io(cache.get_default_queue(), S.from_sector(3).B,

--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -84,3 +84,43 @@ def test_load_cache_recovery(pyocf_ctx):
     cache.stop()
 
     cache = Cache.load_from_device(device_copy)
+
+
+@pytest.mark.parametrize("open_cores", [True, False])
+def test_load_cache_with_cores(pyocf_ctx, open_cores):
+    cache_device = Volume(S.from_MiB(40))
+    core_device = Volume(S.from_MiB(40))
+
+    cache = Cache.start_on_device(cache_device)
+    core = Core.using_device(core_device)
+
+    cache.add_core(core)
+
+    write_data = Data.from_string("This is test data")
+    io = core.new_io(cache.get_default_queue(), S.from_sector(3).B,
+                     write_data.size, IoDir.WRITE, 0, 0)
+    io.set_data(write_data)
+
+    cmpl = OcfCompletion([("err", c_int)])
+    io.callback = cmpl.callback
+    io.submit()
+    cmpl.wait()
+
+    cache.stop()
+
+    cache = Cache.load_from_device(cache_device, open_cores=open_cores)
+    if not open_cores:
+        cache.add_core(core, try_add=True)
+
+    read_data = Data(write_data.size)
+    io = core.new_io(cache.get_default_queue(), S.from_sector(3).B,
+                     read_data.size, IoDir.READ, 0, 0)
+    io.set_data(read_data)
+
+    cmpl = OcfCompletion([("err", c_int)])
+    io.callback = cmpl.callback
+    io.submit()
+    cmpl.wait()
+
+    assert read_data.md5() == write_data.md5()
+    assert core.exp_obj_md5() == core_device.md5()

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -11,7 +11,15 @@ from itertools import count
 import pytest
 
 from pyocf.ocf import OcfLib
-from pyocf.types.cache import Cache, CacheMode, MetadataLayout,  CleaningPolicy
+from pyocf.types.cache import (
+    Cache,
+    CacheMode,
+    MetadataLayout,
+    CleaningPolicy,
+    CacheConfig,
+    PromotionPolicy,
+    Backfill
+)
 from pyocf.types.core import Core
 from pyocf.types.data import Data
 from pyocf.types.io import IoDir
@@ -387,12 +395,14 @@ def test_start_too_small_device(pyocf_ctx, mode, cls):
 
 
 def test_start_stop_noqueue(pyocf_ctx):
-    # cache object just to construct cfg conveniently
-    _cache = Cache(pyocf_ctx.ctx_handle)
+    cfg = CacheConfig()
+    pyocf_ctx.lib.ocf_mngt_cache_config_set_default_wrapper(byref(cfg))
+    cfg._metadata_volatile = True
+    cfg._name = "Test".encode("ascii")
 
     cache_handle = c_void_p()
     status = pyocf_ctx.lib.ocf_mngt_cache_start(
-        pyocf_ctx.ctx_handle, byref(cache_handle), byref(_cache.cfg), None
+        pyocf_ctx.ctx_handle, byref(cache_handle), byref(cfg), None
     )
     assert not status, "Failed to start cache: {}".format(status)
 


### PR DESCRIPTION
This enables load and recovery testing in pyocf by both allowing for try_adding and adding a getter for cores