### PR TITLE
Get rid of struct ocf_cache_line_settings

### DIFF
--- a/src/metadata/metadata_cache_line.h
+++ b/src/metadata/metadata_cache_line.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) 2012-2021 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+#ifndef __METADATA_CACHE_LINE_H__
+#define __METADATA_CACHE_LINE_H__
+
+static inline ocf_cache_line_size_t ocf_line_size(struct ocf_cache *cache)
+{
+	return cache->metadata.line_size;
+}
+
+static inline uint64_t ocf_line_sectors(struct ocf_cache *cache)
+{
+	return BYTES_TO_SECTORS(cache->metadata.line_size);
+}
+
+static inline uint64_t ocf_line_end_sector(struct ocf_cache *cache)
+{
+	return ocf_line_sectors(cache) - 1;
+}
+
+#endif /* __METADATA_CACHE_LINE_H__ */

--- a/src/metadata/metadata_status.h
+++ b/src/metadata/metadata_status.h
@@ -7,6 +7,7 @@
 #define __METADATA_STATUS_H__
 
 #include "../concurrency/ocf_metadata_concurrency.h"
+#include "metadata_cache_line.h"
 
 /*******************************************************************************
  * Dirty
@@ -29,12 +30,8 @@ bool ocf_metadata_test_and_clear_valid(struct ocf_cache *cache, ocf_cache_line_t
 static inline void metadata_init_status_bits(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	ocf_metadata_clear_dirty(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
-	ocf_metadata_clear_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
+	ocf_metadata_clear_dirty(cache, line, 0, ocf_line_end_sector(cache));
+	ocf_metadata_clear_valid(cache, line, 0, ocf_line_end_sector(cache));
 }
 
 static inline bool metadata_test_dirty_all(struct ocf_cache *cache,
@@ -42,9 +39,8 @@ static inline bool metadata_test_dirty_all(struct ocf_cache *cache,
 {
 	bool test;
 
-	test = ocf_metadata_test_dirty(cache, line,
-		cache->metadata.settings.sector_start,
-		cache->metadata.settings.sector_end, true);
+	test = ocf_metadata_test_dirty(cache, line, 0,
+			ocf_line_end_sector(cache), true);
 
 	return test;
 }
@@ -54,9 +50,8 @@ static inline bool metadata_test_dirty(struct ocf_cache *cache,
 {
 	bool test;
 
-	test = ocf_metadata_test_dirty(cache, line,
-		cache->metadata.settings.sector_start,
-		cache->metadata.settings.sector_end, false);
+	test = ocf_metadata_test_dirty(cache, line, 0,
+			ocf_line_end_sector(cache), false);
 
 	return test;
 }
@@ -64,33 +59,27 @@ static inline bool metadata_test_dirty(struct ocf_cache *cache,
 static inline void metadata_set_dirty(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	ocf_metadata_set_dirty(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
+	ocf_metadata_set_dirty(cache, line, 0, ocf_line_end_sector(cache));
 }
 
 static inline void metadata_clear_dirty(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	ocf_metadata_clear_dirty(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
+	ocf_metadata_clear_dirty(cache, line, 0, ocf_line_end_sector(cache));
 }
 
 static inline bool metadata_test_and_clear_dirty(
 		struct ocf_cache *cache, ocf_cache_line_t line)
 {
-	return ocf_metadata_test_and_clear_dirty(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end, false);
+	return ocf_metadata_test_and_clear_dirty(cache, line, 0,
+			ocf_line_end_sector(cache), false);
 }
 
 static inline bool metadata_test_and_set_dirty(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	return ocf_metadata_test_and_set_dirty(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end, false);
+	return ocf_metadata_test_and_set_dirty(cache, line, 0,
+			ocf_line_end_sector(cache), false);
 }
 
 /*******************************************************************************
@@ -202,49 +191,41 @@ static inline bool metadata_set_dirty_sec_changed(
 static inline bool metadata_test_valid_any(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	return ocf_metadata_test_valid(cache, line,
-		cache->metadata.settings.sector_start,
-		cache->metadata.settings.sector_end, false);
+	return ocf_metadata_test_valid(cache, line, 0,
+			ocf_line_end_sector(cache), false);
 }
 
 static inline bool metadata_test_valid(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	return ocf_metadata_test_valid(cache, line,
-		cache->metadata.settings.sector_start,
-		cache->metadata.settings.sector_end, true);
+	return ocf_metadata_test_valid(cache, line, 0,
+			ocf_line_end_sector(cache), true);
 }
 
 static inline void metadata_set_valid(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	ocf_metadata_set_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
+	ocf_metadata_set_valid(cache, line, 0, ocf_line_end_sector(cache));
 }
 
 static inline void metadata_clear_valid(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	ocf_metadata_clear_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end);
+	ocf_metadata_clear_valid(cache, line, 0, ocf_line_end_sector(cache));
 }
 
 static inline bool metadata_test_and_clear_valid(
 		struct ocf_cache *cache, ocf_cache_line_t line)
 {
-	return ocf_metadata_test_and_clear_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end, true);
+	return ocf_metadata_test_and_clear_valid(cache, line, 0,
+			ocf_line_end_sector(cache), true);
 }
 
 static inline bool metadata_test_and_set_valid(struct ocf_cache *cache,
 		ocf_cache_line_t line)
 {
-	return ocf_metadata_test_and_set_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end, true);
+	return ocf_metadata_test_and_set_valid(cache, line, 0,
+			ocf_line_end_sector(cache), true);
 }
 
 /*******************************************************************************
@@ -317,9 +298,8 @@ static inline bool metadata_clear_valid_sec_changed(
 {
 	bool was_any_valid;
 
-	was_any_valid = ocf_metadata_test_valid(cache, line,
-			cache->metadata.settings.sector_start,
-			cache->metadata.settings.sector_end, false);
+	was_any_valid = ocf_metadata_test_valid(cache, line, 0,
+			ocf_line_end_sector(cache), false);
 
 	*is_valid = ocf_metadata_clear_valid(cache, line,
 			start, stop);

--- a/src/metadata/metadata_structs.h
+++ b/src/metadata/metadata_structs.h
@@ -36,14 +36,6 @@ enum ocf_metadata_shutdown_status {
 typedef void (*ocf_metadata_query_cores_end_t)(void *priv, int error,
 		unsigned int num_cores);
 
-struct ocf_cache_line_settings {
-	ocf_cache_line_size_t size;
-	uint64_t sector_count;
-	uint64_t sector_start;
-	uint64_t sector_end;
-};
-
-
 #define OCF_METADATA_GLOBAL_LOCK_IDX_BITS 2
 #define OCF_NUM_GLOBAL_META_LOCKS (1 << (OCF_METADATA_GLOBAL_LOCK_IDX_BITS))
 
@@ -74,8 +66,8 @@ struct ocf_metadata {
 	void *priv;
 		/*!< Private data of metadata service interface */
 
-	const struct ocf_cache_line_settings settings;
-		/*!< Cache line configuration */
+	ocf_cache_line_size_t line_size;
+		/*!< Cache line size */
 
 	bool is_volatile;
 		/*!< true if metadata used in volatile mode (RAM only) */

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -514,8 +514,7 @@ static void _recovery_invalidate_clean_sec(struct ocf_cache *cache,
 {
 	uint8_t i;
 
-	for (i = ocf_line_start_sector(cache);
-			i <= ocf_line_end_sector(cache); i++) {
+	for (i = 0; i <= ocf_line_sectors(cache); i++) {
 		if (!metadata_test_dirty_one(cache, cline, i)) {
 			/* Invalidate clear sectors */
 			metadata_clear_valid_sec_one(cache, cline, i);
@@ -1086,7 +1085,7 @@ static void _ocf_mngt_attach_prepare_metadata(ocf_pipeline_t pipeline,
 	int ret;
 
 	context->metadata.line_size = context->metadata.line_size ?:
-			cache->metadata.settings.size;
+			cache->metadata.line_size;
 
 	/*
 	 * Initialize variable size metadata segments
@@ -2144,7 +2143,7 @@ static void _ocf_mngt_activate_check_superblock_complete(void *priv, int error)
 				-OCF_ERR_METADATA_LAYOUT_MISMATCH);
 	}
 
-	if (cache->conf_meta->line_size != cache->metadata.settings.size) {
+	if (cache->conf_meta->line_size != cache->metadata.line_size) {
 		OCF_PL_FINISH_RET(context->pipeline,
 				-OCF_ERR_CACHE_LINE_SIZE_MISMATCH);
 	}

--- a/src/utils/utils_cache_line.h
+++ b/src/utils/utils_cache_line.h
@@ -19,32 +19,6 @@
  * @brief OCF utilities for cache line operations
  */
 
-static inline ocf_cache_line_size_t ocf_line_size(
-		struct ocf_cache *cache)
-{
-	return cache->metadata.settings.size;
-}
-
-static inline uint64_t ocf_line_pages(struct ocf_cache *cache)
-{
-	return cache->metadata.settings.size / PAGE_SIZE;
-}
-
-static inline uint64_t ocf_line_sectors(struct ocf_cache *cache)
-{
-	return cache->metadata.settings.sector_count;
-}
-
-static inline uint64_t ocf_line_end_sector(struct ocf_cache *cache)
-{
-	return cache->metadata.settings.sector_end;
-}
-
-static inline uint64_t ocf_line_start_sector(struct ocf_cache *cache)
-{
-	return cache->metadata.settings.sector_start;
-}
-
 static inline uint64_t ocf_bytes_round_lines(struct ocf_cache *cache,
 		uint64_t bytes)
 {


### PR DESCRIPTION
Remove struct that contains redundant data.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>