### PR TITLE
Non volatile metadata bug POC

### DIFF
--- a/example/simple/src/volume.h
+++ b/example/simple/src/volume.h
@@ -24,4 +24,6 @@ struct myvolume {
 int volume_init(ocf_ctx_t ocf_ctx);
 void volume_cleanup(ocf_ctx_t ocf_ctx);
 
+bool need_reload_cache();
+
 #endif


### PR DESCRIPTION
#### API: `ocf_mngt_cache_load`

```
cache1: Loading Part config ERROR, invalid checksum
cache1: Metadata read FAILURE
cache1: Metadata Error
cache1: ERROR: Cannot load cache state
```

#### How to reproduce?

This POC is based on the example, it uses two files as cache and core device. `metadata_volatile` is set to false.

Then run the example twice, you will see the first time succeeded, while the second failed when trying to reload cache. 

Error message is as above.