### PR TITLE
Always use async queue kick in management pipeline

### DIFF
--- a/src/utils/utils_pipeline.c
+++ b/src/utils/utils_pipeline.c
@@ -120,12 +120,12 @@ void *ocf_pipeline_get_priv(ocf_pipeline_t pipeline)
 
 void ocf_pipeline_next(ocf_pipeline_t pipeline)
 {
-	ocf_engine_push_req_front(pipeline->req, true);
+	ocf_engine_push_req_front(pipeline->req, false);
 }
 
 void ocf_pipeline_finish(ocf_pipeline_t pipeline, int error)
 {
 	pipeline->finish = true;
 	pipeline->error = error;
-	ocf_engine_push_req_front(pipeline->req, true);
+	ocf_engine_push_req_front(pipeline->req, false);
 }


### PR DESCRIPTION
Management pipelines tend to consist of multiple asynchronous steps.
Allowing synchronous queue kick results in massive call stacks (e.g.
almost 500 functions deep in case of cache stop). Since async kick
is required anyway, it seems reasonable to switch to async kick
in pipeline implementation.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>