### PR TITLE
License change to be approved by contributors

### DIFF
--- a/env/posix/ocf_env.c
+++ b/env/posix/ocf_env.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2019-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf_env.h"

--- a/env/posix/ocf_env.h
+++ b/env/posix/ocf_env.h
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2019-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef __OCF_ENV_H__

--- a/src/cleaning/acp.c
+++ b/src/cleaning/acp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/concurrency/ocf_cache_line_concurrency.c
+++ b/src/concurrency/ocf_cache_line_concurrency.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf_concurrency.h"

--- a/src/concurrency/ocf_metadata_concurrency.c
+++ b/src/concurrency/ocf_metadata_concurrency.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2019-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf_metadata_concurrency.h"

--- a/src/concurrency/ocf_metadata_concurrency.h
+++ b/src/concurrency/ocf_metadata_concurrency.h
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2019-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "../ocf_cache_priv.h"
 #include "../ocf_space.h"

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/metadata/metadata_raw_dynamic.c
+++ b/src/metadata/metadata_raw_dynamic.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "metadata.h"

--- a/src/mngt/ocf_mngt_common.c
+++ b/src/mngt/ocf_mngt_common.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/ocf_ctx.c
+++ b/src/ocf_ctx.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/ocf_io.c
+++ b/src/ocf_io.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/ocf_queue.c
+++ b/src/ocf_queue.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"
 #include "ocf/ocf_queue.h"

--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ocf/ocf.h"

--- a/src/utils/utils_async_lock.c
+++ b/src/utils/utils_async_lock.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(c) 2019-2021 Intel Corporation
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "utils_async_lock.h"


### PR DESCRIPTION
Open CAS and other projects in the Open CAS repo were always intended to be released under the OSI-approved BSD 3-Clause License (SPDX-License-Identifier: BSD-3-Clause), however it was recently discovered that a non-OSI-approved license, the similarly-named BSD 3-Clause “Clear” License (SPDX-License-Identifier: BSD-3-Clause-Clear) was incorrectly applied to many files in these repositories.
 
We are in the process of correcting the error and are asking all contributors to confirm that their contributions were intended to be made under the OSI-approved BSD 3-Clause License. To confirm, please reply to this message and state that your contributions were made under the BSD 3-Clause License. Thank you for your assistance and apologies for any inconvenience.

@mdnfiras @josehu07 @abysdom can you confirm the license change for your contributions?

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>