### PR TITLE
Add promote-on-threshold sequential cutoff switch

### DIFF
--- a/inc/ocf_core.h
+++ b/inc/ocf_core.h
@@ -119,6 +119,16 @@ ocf_seq_cutoff_policy ocf_core_get_seq_cutoff_policy(ocf_core_t core);
 uint32_t ocf_core_get_seq_cutoff_promotion_count(ocf_core_t core);
 
 /**
+ * @brief Whether to promote sequential cutoff stream
+ * to global structures when threshold is reached
+ *
+ * @param[in] core Core object
+ *
+ * @retval Sequential cutoff stream promote_on_threshold switch value
+ */
+bool ocf_core_get_seq_cutoff_promote_on_threshold(ocf_core_t core);
+
+/**
  * @brief Get name of given core object
  *
  * @param[in] core Core object

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -45,6 +45,9 @@ struct ocf_mngt_core_config {
 	uint32_t seq_cutoff_promotion_count;
 		/*!< Sequential cutoff promotion request count */
 
+	bool seq_cutoff_promote_on_threshold;
+		/*!< Sequential cutoff promote on threshold */
+
 	struct {
 		void *data;
 		size_t size;
@@ -65,6 +68,7 @@ static inline void ocf_mngt_core_config_set_default(
 	cfg->try_add = false;
 	cfg->seq_cutoff_threshold = 1024;
 	cfg->seq_cutoff_promotion_count = 8;
+	cfg->seq_cutoff_promote_on_threshold = false;
 	cfg->user_metadata.data = NULL;
 	cfg->user_metadata.size = 0;
 }
@@ -1109,6 +1113,7 @@ int ocf_mngt_core_set_seq_cutoff_promotion_count(ocf_core_t core,
  */
 int ocf_mngt_core_set_seq_cutoff_promotion_count_all(ocf_cache_t cache,
 		uint32_t count);
+
 /**
  * @brief Get core sequential cutoff promotion threshold
  *
@@ -1120,6 +1125,50 @@ int ocf_mngt_core_set_seq_cutoff_promotion_count_all(ocf_cache_t cache,
  */
 int ocf_mngt_core_get_seq_cutoff_promotion_count(ocf_core_t core,
 		uint32_t *count);
+
+/**
+ * @brief Set whether to promote core sequential cutoff stream
+ * to global structures when threshold is reached
+ *
+ * @attention This changes only runtime state. To make changes persistent
+ *            use function ocf_mngt_cache_save().
+ *
+ * @param[in] core Core handle
+ * @param[in] promote Whether to promote or not
+ *
+ * @retval 0 Sequential cutoff promote on threshold has been set successfully
+ * @retval Non-zero Error occured and promote on threshold hasn't been updated
+ */
+int ocf_mngt_core_set_seq_cutoff_promote_on_threshold(ocf_core_t core,
+		bool promote);
+
+/**
+ * @brief Set whether to promote sequential cutoff stream
+ * to global structures when threshold is reached for all cores in cache
+ *
+ * @attention This changes only runtime state. To make changes persistent
+ *            use function ocf_mngt_cache_save().
+ *
+ * @param[in] cache Cache handle
+ * @param[in] promote Whether to promote or not
+ *
+ * @retval 0 Sequential cutoff promote on threshold has been set successfully
+ * @retval Non-zero Error occured and promote on threshold hasn't been updated
+ */
+int ocf_mngt_core_set_seq_cutoff_promote_on_threshold_all(ocf_cache_t cache,
+		bool promote);
+
+/**
+ * @brief Get core sequential cutoff promote on threshold switch value
+ *
+ * @param[in] core Core handle
+ * @param[out] promote Promote on threshold
+ *
+ * @retval 0 Sequential cutoff promote on threshold retrieved successfully
+ * @retval Non-zero Error occured and value could not be retrieved
+ */
+int ocf_mngt_core_get_seq_cutoff_promote_on_threshold(ocf_core_t core,
+		bool *promote);
 
 /**
  * @brief Set cache fallback Pass Through error threshold

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -121,6 +121,11 @@ uint32_t ocf_core_get_seq_cutoff_promotion_count(ocf_core_t core)
 	return env_atomic_read(&core->conf_meta->seq_cutoff_promo_count);
 }
 
+bool ocf_core_get_seq_cutoff_promote_on_threshold(ocf_core_t core)
+{
+	return env_atomic_read(&core->conf_meta->seq_cutoff_promote_on_threshold);
+}
+
 int ocf_core_visit(ocf_cache_t cache, ocf_core_visitor_t visitor, void *cntx,
 		bool only_opened)
 {

--- a/src/ocf_core_priv.h
+++ b/src/ocf_core_priv.h
@@ -47,6 +47,9 @@ struct ocf_core_meta_config {
 	/* Sequential cutoff stream promotion request count */
 	env_atomic seq_cutoff_promo_count;
 
+	/* Sequential cutoff stream promote on threshold */
+	env_atomic seq_cutoff_promote_on_threshold;
+
 	/* core object size in bytes */
 	uint64_t length;
 

--- a/src/ocf_seq_cutoff.c
+++ b/src/ocf_seq_cutoff.c
@@ -300,13 +300,15 @@ void ocf_core_seq_cutoff_update(ocf_core_t core, struct ocf_request *req)
 	uint32_t threshold = ocf_core_get_seq_cutoff_threshold(core);
 	uint32_t promotion_count =
 			ocf_core_get_seq_cutoff_promotion_count(core);
+	bool promote_on_threshold =
+			ocf_core_get_seq_cutoff_promote_on_threshold(core);
 	struct ocf_seq_cutoff_stream *stream;
 	bool promote = false;
 
 	if (policy == ocf_seq_cutoff_policy_never)
 		return;
 
-	if (req->byte_length >= threshold)
+	if (req->byte_length >= threshold && promote_on_threshold)
 		promote = true;
 
 	if (promotion_count == 1)
@@ -328,7 +330,7 @@ void ocf_core_seq_cutoff_update(ocf_core_t core, struct ocf_request *req)
 			req->byte_position, req->byte_length, req->rw, true);
 	env_rwlock_write_unlock(&req->io_queue->seq_cutoff->lock);
 
-	if (stream->bytes >= threshold)
+	if (stream->bytes >= threshold && promote_on_threshold)
 		promote = true;
 
 	if (stream->req_count >= promotion_count)


### PR DESCRIPTION
Decide whether to promote sequential cutoff stream
to global structures when threshold is reached

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>