### PR TITLE
Fix for OCL issue #968 -  GCC 11 compilation error

### DIFF
--- a/src/metadata/metadata_io.c
+++ b/src/metadata/metadata_io.c
@@ -529,7 +529,8 @@ int ocf_metadata_io_ctx_init(struct ocf_ctx *ocf_ctx)
 {
 	uint32_t limits[] = {
 		[0 ... MIO_RPOOL_THRESHOLD - 1] = -1,
-		[MIO_RPOOL_THRESHOLD ... ocf_mio_size_max - 1] = MIO_RPOOL_LIMIT
+		[MIO_RPOOL_THRESHOLD ... ocf_mio_size_max - 1] = MIO_RPOOL_LIMIT,
+		[ocf_mio_size_max ... env_mpool_max] = -1,
 	};
 
 	ocf_ctx->resources.mio = env_mpool_create(


### PR DESCRIPTION
GCC 11 static check finds an array size mismatch and prevents OCF from
compiling correctly. This fixes OpenCAS Linux issue #968

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>