### PR TITLE
Fix _cas_cleaner_thread stuck when cleaning not performed(ocf)

### DIFF
--- a/inc/ocf_cleaner.h
+++ b/inc/ocf_cleaner.h
@@ -35,8 +35,10 @@ void ocf_cleaner_set_cmpl(ocf_cleaner_t cleaner, ocf_cleaner_end_t fn);
  *
  * @param[in] c Cleaner instance to run
  * @param[in] queue IO queue handle
+ *
+ * @retval Whether cleaning performed
  */
-void ocf_cleaner_run(ocf_cleaner_t c, ocf_queue_t queue);
+bool ocf_cleaner_run(ocf_cleaner_t c, ocf_queue_t queue);
 
 /**
  * @brief Set cleaner private data

--- a/src/cleaning/cleaning_ops.h
+++ b/src/cleaning/cleaning_ops.h
@@ -251,13 +251,13 @@ static inline int ocf_cleaning_get_param(ocf_cache_t cache,
 			param_value);
 }
 
-static inline void ocf_cleaning_perform_cleaning(ocf_cache_t cache,
+static inline bool ocf_cleaning_perform_cleaning(ocf_cache_t cache,
 		ocf_cleaner_end_t cmpl)
 {
 	ocf_cleaning_t policy;
 
 	if (unlikely(!ocf_refcnt_inc(&cache->cleaner.refcnt)))
-		return;
+		return false;
 
 	policy = cache->cleaner.policy;
 	ENV_BUG_ON(policy >= ocf_cleaning_max);
@@ -266,9 +266,11 @@ static inline void ocf_cleaning_perform_cleaning(ocf_cache_t cache,
 		goto unlock;
 
 	cleaning_policy_ops[policy].perform_cleaning(cache, cmpl);
+	return true;
 
 unlock:
 	ocf_refcnt_dec(&cache->cleaner.refcnt);
+	return false;
 }
 
 static inline const char *ocf_cleaning_get_name(ocf_cleaning_t policy)


### PR DESCRIPTION
when ocf_cleaner_run can't perform cleaning for some reasons,
it will not call _cas_cleaner_complete to complete info->sync_compl,
_cas_cleaner_thread will stuck for waiting this completion.

[ 1694.477896] INFO: task cas_cl_cache1:1909 blocked for more than 120 seconds.
[ 1694.479252]       Tainted: G           OE     4.19.90+pitrix1 #1
[ 1694.480453] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[ 1694.482023] cas_cl_cache1   D    0  1909      2 0x00000028
[ 1694.482027] Call trace:
[ 1694.482033]  __switch_to+0xf0/0x150
[ 1694.482044]  __schedule+0x2ac/0x718
[ 1694.482050]  schedule+0x30/0xe8
[ 1694.482055]  schedule_timeout+0x244/0x388
[ 1694.482064]  wait_for_common+0x180/0x280
[ 1694.482068]  wait_for_completion+0x28/0x38
[ 1694.482103]  _cas_cleaner_thread+0xec/0x208 [cas_cache]
[ 1694.482107]  kthread+0x134/0x138
[ 1694.482109]  ret_from_fork+0x10/0x18

Signed-off-by: Sun Feng <loyou85@gmail.com>