### PR TITLE
Don't stop cleaner in activate rollback

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -2300,9 +2300,6 @@ static void _ocf_mngt_activate_handle_error(
 {
 	ocf_cache_t cache = context->cache;
 
-	if (context->flags.cleaner_started)
-		ocf_stop_cleaner(cache);
-
 	if (context->flags.promotion_initialized)
 		__deinit_promotion_policy(cache);
 


### PR DESCRIPTION
Activate is not responsible for starting cleaner so rollback shouldn't stop it
eiter.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>