### PR TITLE
utils: call io_put before completion function

### DIFF
--- a/src/utils/utils_io.c
+++ b/src/utils/utils_io.c
@@ -21,9 +21,10 @@ struct ocf_submit_volume_context {
 static void _ocf_volume_flush_end(struct ocf_io *io, int error)
 {
 	ocf_submit_end_t cmpl = io->priv1;
+	void *param = io->priv2;
 
-	cmpl(io->priv2, error);
 	ocf_io_put(io);
+	cmpl(param, error);
 }
 
 void ocf_submit_volume_flush(ocf_volume_t volume,


### PR DESCRIPTION
In the simple example, after calling ocf_mngt_cache_stop, the program
never exit while it waits endlessly for the volume's reference count
to reach zero. Changing the functions call order reduce the reference
count before the flush continue its work.

Signed-off-by: Gal Hammer <gal.hammer@huawei.com>
Signed-off-by: Shai Fultheim <shai.fultheim@huawei.com>