### PR TITLE
[v21.3.4] Check superblock CRC before it is used

### DIFF
--- a/src/metadata/metadata_superblock.c
+++ b/src/metadata/metadata_superblock.c
@@ -225,7 +225,6 @@ struct ocf_pipeline_arg ocf_metadata_load_sb_store_segment_args[] = {
 };
 
 struct ocf_pipeline_arg ocf_metadata_load_sb_load_segment_args[] = {
-	OCF_PL_ARG_INT(metadata_segment_sb_config),
 	OCF_PL_ARG_INT(metadata_segment_sb_runtime),
 	OCF_PL_ARG_INT(metadata_segment_part_config),
 	OCF_PL_ARG_INT(metadata_segment_part_runtime),
@@ -253,9 +252,11 @@ struct ocf_pipeline_properties ocf_metadata_load_sb_pipeline_props = {
 	.steps = {
 		OCF_PL_STEP_FOREACH(ocf_metadata_store_segment,
 				ocf_metadata_load_sb_store_segment_args),
+		OCF_PL_STEP_ARG_INT(ocf_metadata_load_segment,
+				metadata_segment_sb_config),
+		OCF_PL_STEP(ocf_metadata_check_crc_sb_config),
 		OCF_PL_STEP_FOREACH(ocf_metadata_load_segment,
 				ocf_metadata_load_sb_load_segment_args),
-		OCF_PL_STEP(ocf_metadata_check_crc_sb_config),
 		OCF_PL_STEP_FOREACH(ocf_metadata_check_crc,
 				ocf_metadata_load_sb_check_crc_args),
 		OCF_PL_STEP_FOREACH(ocf_metadata_check_crc_if_clean,


### PR DESCRIPTION
Superblock can be used during load of other sections, so we need to check
its CRC before other sections are loaded.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>