### PR TITLE
Remove edition date from file headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright(c) 2019-2021 Intel Corporation
+Copyright(c) 2019 Intel Corporation
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/env/posix/ocf_env.c
+++ b/env/posix/ocf_env.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/env/posix/ocf_env.h
+++ b/env/posix/ocf_env.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/env/posix/ocf_env_headers.h
+++ b/env/posix/ocf_env_headers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/env/posix/ocf_env_list.h
+++ b/env/posix/ocf_env_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/env/posix/utils_mpool.c
+++ b/env/posix/utils_mpool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/env/posix/utils_mpool.h
+++ b/env/posix/utils_mpool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/Makefile
+++ b/example/simple/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/example/simple/src/ctx.c
+++ b/example/simple/src/ctx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/ctx.h
+++ b/example/simple/src/ctx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/data.h
+++ b/example/simple/src/data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/main.c
+++ b/example/simple/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/queue_thread.c
+++ b/example/simple/src/queue_thread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021-2021 Intel Corporation
+ * Copyright(c) 2021 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/queue_thread.h
+++ b/example/simple/src/queue_thread.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021-2021 Intel Corporation
+ * Copyright(c) 2021 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/volume.c
+++ b/example/simple/src/volume.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/example/simple/src/volume.h
+++ b/example/simple/src/volume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/cleaning/acp.h
+++ b/inc/cleaning/acp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __OCF_CLEANING_ACP_H__

--- a/inc/cleaning/alru.h
+++ b/inc/cleaning/alru.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __OCF_CLEANING_ALRU_H__

--- a/inc/ocf.h
+++ b/inc/ocf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_cache.h
+++ b/inc/ocf_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_cfg.h
+++ b/inc/ocf_cfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_cleaner.h
+++ b/inc/ocf_cleaner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_core.h
+++ b/inc/ocf_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_ctx.h
+++ b/inc/ocf_ctx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_debug.h
+++ b/inc/ocf_debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_def.h
+++ b/inc/ocf_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_err.h
+++ b/inc/ocf_err.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_io.h
+++ b/inc/ocf_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_io_class.h
+++ b/inc/ocf_io_class.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_logger.h
+++ b/inc/ocf_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_metadata.h
+++ b/inc/ocf_metadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_queue.h
+++ b/inc/ocf_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_stats.h
+++ b/inc/ocf_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_types.h
+++ b/inc/ocf_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/ocf_volume.h
+++ b/inc/ocf_volume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/inc/promotion/nhit.h
+++ b/inc/promotion/nhit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/acp.c
+++ b/src/cleaning/acp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/acp.h
+++ b/src/cleaning/acp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __LAYER_CLEANING_POLICY_AGGRESSIVE_H__

--- a/src/cleaning/acp_structs.h
+++ b/src/cleaning/acp_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __CLEANING_AGGRESSIVE_STRUCTS_H__

--- a/src/cleaning/alru.c
+++ b/src/cleaning/alru.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/alru.h
+++ b/src/cleaning/alru.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __LAYER_CLEANING_POLICY_ALRU_H__

--- a/src/cleaning/alru_structs.h
+++ b/src/cleaning/alru_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __CLEANING_ALRU_STRUCTS_H__

--- a/src/cleaning/cleaning.c
+++ b/src/cleaning/cleaning.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/cleaning.h
+++ b/src/cleaning/cleaning.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/cleaning_ops.h
+++ b/src/cleaning/cleaning_ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/cleaning_priv.h
+++ b/src/cleaning/cleaning_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/nop.c
+++ b/src/cleaning/nop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/nop.h
+++ b/src/cleaning/nop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/cleaning/nop_structs.h
+++ b/src/cleaning/nop_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __LAYER_CLEANING_POLICY_NOP_STRUCTS_H__

--- a/src/concurrency/ocf_cache_line_concurrency.c
+++ b/src/concurrency/ocf_cache_line_concurrency.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_cache_line_concurrency.h
+++ b/src/concurrency/ocf_cache_line_concurrency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_concurrency.c
+++ b/src/concurrency/ocf_concurrency.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_concurrency.h
+++ b/src/concurrency/ocf_concurrency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_metadata_concurrency.c
+++ b/src/concurrency/ocf_metadata_concurrency.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_metadata_concurrency.h
+++ b/src/concurrency/ocf_metadata_concurrency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "../ocf_cache_priv.h"

--- a/src/concurrency/ocf_mio_concurrency.h
+++ b/src/concurrency/ocf_mio_concurrency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021-2021 Intel Corporation
+ * Copyright(c) 2021 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/concurrency/ocf_pio_concurrency.h
+++ b/src/concurrency/ocf_pio_concurrency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021-2021 Intel Corporation
+ * Copyright(c) 2021 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/cache_engine.c
+++ b/src/engine/cache_engine.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/cache_engine.h
+++ b/src/engine/cache_engine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_bf.c
+++ b/src/engine/engine_bf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_bf.h
+++ b/src/engine/engine_bf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_common.c
+++ b/src/engine/engine_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_common.h
+++ b/src/engine/engine_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_d2c.c
+++ b/src/engine/engine_d2c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/engine/engine_d2c.h
+++ b/src/engine/engine_d2c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_debug.h
+++ b/src/engine/engine_debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/engine/engine_discard.h
+++ b/src/engine/engine_discard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_fast.c
+++ b/src/engine/engine_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_fast.h
+++ b/src/engine/engine_fast.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_inv.c
+++ b/src/engine/engine_inv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_inv.h
+++ b/src/engine/engine_inv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_ops.c
+++ b/src/engine/engine_ops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/engine/engine_ops.h
+++ b/src/engine/engine_ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_pt.c
+++ b/src/engine/engine_pt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/engine/engine_pt.h
+++ b/src/engine/engine_pt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_rd.c
+++ b/src/engine/engine_rd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_rd.h
+++ b/src/engine/engine_rd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wa.c
+++ b/src/engine/engine_wa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/engine/engine_wa.h
+++ b/src/engine/engine_wa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wb.c
+++ b/src/engine/engine_wb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wb.h
+++ b/src/engine/engine_wb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef ENGINE_WB_H_

--- a/src/engine/engine_wi.c
+++ b/src/engine/engine_wi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wi.h
+++ b/src/engine/engine_wi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wo.c
+++ b/src/engine/engine_wo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wo.h
+++ b/src/engine/engine_wo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wt.c
+++ b/src/engine/engine_wt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_wt.h
+++ b/src/engine/engine_wt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_zero.c
+++ b/src/engine/engine_zero.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/engine/engine_zero.h
+++ b/src/engine/engine_zero.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata.c
+++ b/src/metadata/metadata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata.h
+++ b/src/metadata/metadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_bit.h
+++ b/src/metadata/metadata_bit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_cache_line.h
+++ b/src/metadata/metadata_cache_line.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_cleaning_policy.c
+++ b/src/metadata/metadata_cleaning_policy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_cleaning_policy.h
+++ b/src/metadata/metadata_cleaning_policy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_collision.c
+++ b/src/metadata/metadata_collision.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_collision.h
+++ b/src/metadata/metadata_collision.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_common.h
+++ b/src/metadata/metadata_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_core.c
+++ b/src/metadata/metadata_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_core.h
+++ b/src/metadata/metadata_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_eviction_policy.c
+++ b/src/metadata/metadata_eviction_policy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_eviction_policy.h
+++ b/src/metadata/metadata_eviction_policy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_internal.h
+++ b/src/metadata/metadata_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_io.c
+++ b/src/metadata/metadata_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "metadata.h"

--- a/src/metadata/metadata_io.h
+++ b/src/metadata/metadata_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_misc.c
+++ b/src/metadata/metadata_misc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_misc.h
+++ b/src/metadata/metadata_misc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_partition.c
+++ b/src/metadata/metadata_partition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_partition.h
+++ b/src/metadata/metadata_partition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_partition_structs.h
+++ b/src/metadata/metadata_partition_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_passive_update.c
+++ b/src/metadata/metadata_passive_update.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_passive_update.h
+++ b/src/metadata/metadata_passive_update.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw.c
+++ b/src/metadata/metadata_raw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw.h
+++ b/src/metadata/metadata_raw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_atomic.c
+++ b/src/metadata/metadata_raw_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_atomic.h
+++ b/src/metadata/metadata_raw_atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_dynamic.c
+++ b/src/metadata/metadata_raw_dynamic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_dynamic.h
+++ b/src/metadata/metadata_raw_dynamic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_volatile.c
+++ b/src/metadata/metadata_raw_volatile.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_raw_volatile.h
+++ b/src/metadata/metadata_raw_volatile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_segment.c
+++ b/src/metadata/metadata_segment.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "metadata_internal.h"

--- a/src/metadata/metadata_segment.h
+++ b/src/metadata/metadata_segment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_segment_id.h
+++ b/src/metadata/metadata_segment_id.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_status.h
+++ b/src/metadata/metadata_status.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_structs.h
+++ b/src/metadata/metadata_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_superblock.c
+++ b/src/metadata/metadata_superblock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/metadata/metadata_superblock.h
+++ b/src/metadata/metadata_superblock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_common.c
+++ b/src/mngt/ocf_mngt_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_common.h
+++ b/src/mngt/ocf_mngt_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_core_pool.c
+++ b/src/mngt/ocf_mngt_core_pool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_core_pool_priv.h
+++ b/src/mngt/ocf_mngt_core_pool_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_core_priv.h
+++ b/src/mngt/ocf_mngt_core_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_flush.c
+++ b/src/mngt/ocf_mngt_flush.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_io_class.c
+++ b/src/mngt/ocf_mngt_io_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/mngt/ocf_mngt_misc.c
+++ b/src/mngt/ocf_mngt_misc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_cache.c
+++ b/src/ocf_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_cache_priv.h
+++ b/src/ocf_cache_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_core_priv.h
+++ b/src/ocf_core_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_ctx.c
+++ b/src/ocf_ctx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_ctx_priv.h
+++ b/src/ocf_ctx_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_def_priv.h
+++ b/src/ocf_def_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_io.c
+++ b/src/ocf_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_io_class.c
+++ b/src/ocf_io_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_io_priv.h
+++ b/src/ocf_io_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_logger.c
+++ b/src/ocf_logger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_logger_priv.h
+++ b/src/ocf_logger_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_lru.c
+++ b/src/ocf_lru.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_lru.h
+++ b/src/ocf_lru.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __EVICTION_LRU_H__

--- a/src/ocf_lru_structs.h
+++ b/src/ocf_lru_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __EVICTION_LRU_STRUCTS_H__

--- a/src/ocf_metadata.c
+++ b/src/ocf_metadata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf_priv.h"

--- a/src/ocf_priv.h
+++ b/src/ocf_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __OCF_PRIV_H__

--- a/src/ocf_queue.c
+++ b/src/ocf_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/ocf_queue_priv.h
+++ b/src/ocf_queue_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_request.c
+++ b/src/ocf_request.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_seq_cutoff.c
+++ b/src/ocf_seq_cutoff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_seq_cutoff.h
+++ b/src/ocf_seq_cutoff.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_space.c
+++ b/src/ocf_space.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_space.h
+++ b/src/ocf_space.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_stats.c
+++ b/src/ocf_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_stats_builder.c
+++ b/src/ocf_stats_builder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_stats_priv.h
+++ b/src/ocf_stats_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_volume.c
+++ b/src/ocf_volume.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/ocf_volume_priv.h
+++ b/src/ocf_volume_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/nhit/nhit.c
+++ b/src/promotion/nhit/nhit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/nhit/nhit.h
+++ b/src/promotion/nhit/nhit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/nhit/nhit_hash.c
+++ b/src/promotion/nhit/nhit_hash.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/nhit/nhit_hash.h
+++ b/src/promotion/nhit/nhit_hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/nhit/nhit_structs.h
+++ b/src/promotion/nhit/nhit_structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef __PROMOTION_NHIT_STRUCTS_H_

--- a/src/promotion/ops.h
+++ b/src/promotion/ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/promotion.c
+++ b/src/promotion/promotion.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/promotion/promotion.h
+++ b/src/promotion/promotion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_alock.c
+++ b/src/utils/utils_alock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_alock.h
+++ b/src/utils/utils_alock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef OCF_UTILS_ALOCK_H_

--- a/src/utils/utils_async_lock.c
+++ b/src/utils/utils_async_lock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_async_lock.h
+++ b/src/utils/utils_async_lock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_cache_line.c
+++ b/src/utils/utils_cache_line.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_cache_line.h
+++ b/src/utils/utils_cache_line.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_cleaner.c
+++ b/src/utils/utils_cleaner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_cleaner.h
+++ b/src/utils/utils_cleaner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_io.c
+++ b/src/utils/utils_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_io.h
+++ b/src/utils/utils_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_io_allocator.h
+++ b/src/utils/utils_io_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_list.c
+++ b/src/utils/utils_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_list.h
+++ b/src/utils/utils_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_pipeline.c
+++ b/src/utils/utils_pipeline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_pipeline.h
+++ b/src/utils/utils_pipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_rbtree.c
+++ b/src/utils/utils_rbtree.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_rbtree.h
+++ b/src/utils/utils_rbtree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020-2021 Intel Corporation
+ * Copyright(c) 2020 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_realloc.c
+++ b/src/utils/utils_realloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"

--- a/src/utils/utils_realloc.h
+++ b/src/utils/utils_realloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_refcnt.c
+++ b/src/utils/utils_refcnt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_refcnt.h
+++ b/src/utils/utils_refcnt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019-2021 Intel Corporation
+ * Copyright(c) 2019 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_request.c
+++ b/src/utils/utils_request.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2020 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_request.h
+++ b/src/utils/utils_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_stats.h
+++ b/src/utils/utils_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_user_part.c
+++ b/src/utils/utils_user_part.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/utils/utils_user_part.h
+++ b/src/utils/utils_user_part.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/build/Makefile
+++ b/tests/build/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/ocf.py
+++ b/tests/functional/pyocf/ocf.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 from ctypes import c_void_p, cdll

--- a/tests/functional/pyocf/types/cache.py
+++ b/tests/functional/pyocf/types/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/cleaner.py
+++ b/tests/functional/pyocf/types/cleaner.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/core.py
+++ b/tests/functional/pyocf/types/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/ctx.py
+++ b/tests/functional/pyocf/types/ctx.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/data.py
+++ b/tests/functional/pyocf/types/data.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/io.py
+++ b/tests/functional/pyocf/types/io.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/ioclass.py
+++ b/tests/functional/pyocf/types/ioclass.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/logger.py
+++ b/tests/functional/pyocf/types/logger.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/queue.py
+++ b/tests/functional/pyocf/types/queue.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/shared.py
+++ b/tests/functional/pyocf/types/shared.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/stats/cache.py
+++ b/tests/functional/pyocf/types/stats/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/stats/core.py
+++ b/tests/functional/pyocf/types/stats/core.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/stats/shared.py
+++ b/tests/functional/pyocf/types/stats/shared.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/types/volume.py
+++ b/tests/functional/pyocf/types/volume.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/utils.py
+++ b/tests/functional/pyocf/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/pyocf/wrappers/ocf_io_wrappers.c
+++ b/tests/functional/pyocf/wrappers/ocf_io_wrappers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/functional/pyocf/wrappers/ocf_logger_wrappers.c
+++ b/tests/functional/pyocf/wrappers/ocf_logger_wrappers.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/functional/pyocf/wrappers/ocf_volume_wrappers.c
+++ b/tests/functional/pyocf/wrappers/ocf_volume_wrappers.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/functional/tests/basic/test_pyocf.py
+++ b/tests/functional/tests/basic/test_pyocf.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/conftest.py
+++ b/tests/functional/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/engine/test_io_flags.py
+++ b/tests/functional/tests/engine/test_io_flags.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/engine/test_pp.py
+++ b/tests/functional/tests/engine/test_pp.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/engine/test_read.py
+++ b/tests/functional/tests/engine/test_read.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/engine/test_seq_cutoff.py
+++ b/tests/functional/tests/engine/test_seq_cutoff.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/eviction/test_eviction.py
+++ b/tests/functional/tests/eviction/test_eviction.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/flush/test_flush_after_mngmt.py
+++ b/tests/functional/tests/flush/test_flush_after_mngmt.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/management/test_add_remove.py
+++ b/tests/functional/tests/management/test_add_remove.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/management/test_attach_cache.py
+++ b/tests/functional/tests/management/test_attach_cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/management/test_change_params.py
+++ b/tests/functional/tests/management/test_change_params.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/management/test_start_stop.py
+++ b/tests/functional/tests/management/test_start_stop.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/security/conftest.py
+++ b/tests/functional/tests/security/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/security/test_management_fuzzy.py
+++ b/tests/functional/tests/security/test_management_fuzzy.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/security/test_management_start_fuzzy.py
+++ b/tests/functional/tests/security/test_management_start_fuzzy.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/security/test_negative_io.py
+++ b/tests/functional/tests/security/test_negative_io.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/security/test_secure_erase.py
+++ b/tests/functional/tests/security/test_secure_erase.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/tests/utils/random.py
+++ b/tests/functional/tests/utils/random.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/functional/utils/configure_random.py
+++ b/tests/functional/utils/configure_random.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/framework/add_new_test_file.py
+++ b/tests/unit/framework/add_new_test_file.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/framework/prepare_sources_for_testing.py
+++ b/tests/unit/framework/prepare_sources_for_testing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/framework/run_unit_tests.py
+++ b/tests/unit/framework/run_unit_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/framework/tests_config.py
+++ b/tests/unit/framework/tests_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/tests/add_new_test_file.py
+++ b/tests/unit/tests/add_new_test_file.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tests/unit/tests/cleaning/alru.c/cleaning_policy_alru_initialize_part_test.c
+++ b/tests/unit/tests/cleaning/alru.c/cleaning_policy_alru_initialize_part_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 /*

--- a/tests/unit/tests/cleaning/cleaning.c/ocf_cleaner_run_test.c
+++ b/tests/unit/tests/cleaning/cleaning.c/ocf_cleaner_run_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/unit/tests/header.c
+++ b/tests/unit/tests/header.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
+++ b/tests/unit/tests/mngt/ocf_mngt_cache.c/_cache_mngt_set_cache_mode_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/unit/tests/mngt/ocf_mngt_io_class.c/ocf_mngt_io_class.c
+++ b/tests/unit/tests/mngt/ocf_mngt_io_class.c/ocf_mngt_io_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/unit/tests/print_desc.h
+++ b/tests/unit/tests/print_desc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/tests/unit/tests/utils/utils_rbtree.c/utils_rbtree.c
+++ b/tests/unit/tests/utils/utils_rbtree.c/utils_rbtree.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 


### PR DESCRIPTION
Leave only file creation date. Edition dates can be easily obtained from
the git repository.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>