### PR TITLE
Handle a coredump when SPDK send a flush request

### DIFF
--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -361,6 +361,12 @@ static void ocf_core_volume_submit_flush(struct ocf_io *io)
 		return;
 	}
 
+	ret = ocf_req_alloc_map_flush(req);
+	if (ret) {
+		ocf_io_end(io, -OCF_ERR_NO_MEM);
+		return;
+	}
+
 	req->core = core;
 	req->complete = ocf_req_complete;
 

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -279,6 +279,16 @@ int ocf_req_alloc_map(struct ocf_request *req);
 int ocf_req_alloc_map_discard(struct ocf_request *req);
 
 /**
+ * @brief Allocate OCF request map for flush request
+ *
+ * @param req OCF request
+ *
+ * @retval 0 Allocation succeed
+ * @retval non-zero Allocation failed
+ */
+int ocf_req_alloc_map_flush(struct ocf_request *req);
+
+/**
  * @brief Allocate new OCF request with NOIO map allocation for huge request
  *
  * @param queue - I/O queue handle


### PR DESCRIPTION
While trying to work with SPDK and OCF I had a core dump when a VM's disk is unmounted (due to FLUSH request). I created a test which reproduce this issue and suggested fixes.

Your comments are welcomed.

Thanks, Gal.