### PR TITLE
Make core remove error recoverable

### DIFF
--- a/inc/ocf_err.h
+++ b/inc/ocf_err.h
@@ -146,7 +146,10 @@ typedef enum {
 	/** Operation invalid with cache drive atatched in failover standby */
 	OCF_ERR_STANDBY_ATTACHED,
 
-	OCF_ERR_MAX = OCF_ERR_STANDBY_ATTACHED,
+	/** Failed to remove the core */
+	OCF_ERR_CORE_NOT_REMOVED,
+
+	OCF_ERR_MAX = OCF_ERR_CORE_NOT_REMOVED,
 
 } ocf_error_t;
 

--- a/tests/functional/pyocf/types/shared.py
+++ b/tests/functional/pyocf/types/shared.py
@@ -56,6 +56,7 @@ class OcfErrorCode(IntEnum):
     OCF_ERR_CACHE_STANDBY = auto()
     OCF_ERR_CORE_SIZE_MISMATCH = auto()
     OCF_ERR_STANDBY_ATTACHED = auto()
+    OCF_ERR_CORE_NOT_REMOVED = auto()
 
 
 class OcfCompletion:


### PR DESCRIPTION
First try to clean only the mapping. This operation does not require any
rollback, so even if flushing collision fails, core object is still
intact. In case of error we inform user that core was not removed by
returning new error code (-OCF_ERR_CORE_NOT_REMOVED).

After flushing collision succeeds we remove core from metadata and
flush superblock at the end. At that point the core is fully removed
from OCF and even if superblock flush error occurs there is nothing we
can do about it, so we just return the error code.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>