### PR TITLE
Fix statistics collection in standby mode

### DIFF
--- a/src/ocf_stats_builder.c
+++ b/src/ocf_stats_builder.c
@@ -410,6 +410,9 @@ int ocf_stats_collect_cache(ocf_cache_t cache,
 	_ocf_stats_zero(blocks);
 	_ocf_stats_zero(errors);
 
+	if (ocf_cache_is_standby(cache))
+		return 0;
+
 	result = ocf_core_visit(cache, _accumulate_stats, &s, true);
 	if (result)
 		return result;


### PR DESCRIPTION
Exit early from statistics function before attempting to
iterate over cores in case cache is in standby.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>