### PR TITLE
Fix error code for superblock checksum mismatch

### DIFF
--- a/src/metadata/metadata_superblock.c
+++ b/src/metadata/metadata_superblock.c
@@ -127,7 +127,7 @@ int ocf_metadata_validate_superblock(ocf_ctx_t ctx,
 
 	if (crc != superblock->checksum[metadata_segment_sb_config]) {
 		ocf_log_invalid_superblock("checksum");
-		return -OCF_ERR_INVAL;
+		return -OCF_ERR_CRC_MISMATCH;
 	}
 
 	if (superblock->clean_shutdown > ocf_metadata_clean_shutdown) {


### PR DESCRIPTION
Fix error code for superblock checksum mismatch.
Superblock validation now returns a proper error on checksum check fail.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>