### PR TITLE
Remove space from names of internal volumes

### DIFF
--- a/src/ocf_cache.c
+++ b/src/ocf_cache.c
@@ -512,7 +512,7 @@ static ctx_data_t *ocf_cache_io_get_data(struct ocf_io *io)
 }
 
 const struct ocf_volume_properties ocf_cache_volume_properties = {
-	.name = "OCF Cache",
+	.name = "OCF_Cache",
 	.io_priv_size = sizeof(struct ocf_cache_volume_io_priv),
 	.volume_priv_size = sizeof(struct ocf_cache_volume),
 	.caps = {

--- a/src/ocf_core.c
+++ b/src/ocf_core.c
@@ -479,7 +479,7 @@ static ctx_data_t *ocf_core_io_get_data(struct ocf_io *io)
 }
 
 const struct ocf_volume_properties ocf_core_volume_properties = {
-	.name = "OCF Core",
+	.name = "OCF_Core",
 	.io_priv_size = 0, /* Not used - custom allocator */
 	.volume_priv_size = sizeof(struct ocf_core_volume),
 	.caps = {


### PR DESCRIPTION
Those names are used for creating allocators. In Linux kernel environment
starting from version 5.12 there is a kernel warning if allocator name
contains spaces. This patch resolves this problem by replacing spaces with
underscores.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>