### PR TITLE
pyocf utils: add missing cmp operators in Size

### DIFF
--- a/tests/functional/pyocf/utils.py
+++ b/tests/functional/pyocf/utils.py
@@ -176,6 +176,21 @@ class Size:
     def __eq__(self, other):
         return self.bytes == other.bytes
 
+    def __lt__(self, other):
+        return self.bytes < other.bytes
+
+    def __gt__(self, other):
+        return self.bytes > other.bytes
+
+    def __le__(self, other):
+        return self.bytes <= other.bytes
+
+    def __ge__(self, other):
+        return self.bytes >= other.bytes
+
+    def __ne__(self, other):
+        return self.bytes != other.bytes
+
     def __add__(self, other):
         return Size(self.bytes + other.bytes)
 


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>
Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>