### PR TITLE
Use internal implementation of DIV_ROUND_UP

### DIFF
--- a/src/cleaning/acp.c
+++ b/src/cleaning/acp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -363,7 +363,7 @@ static int ocf_acp_recovery_handle(ocf_parallelize_t parallelize,
 	ocf_core_id_t core_id;
 	uint32_t step = 0;
 
-	portion = DIV_ROUND_UP((uint64_t)entries, shards_cnt);
+	portion = OCF_DIV_ROUND_UP((uint64_t)entries, shards_cnt);
 	begin = portion*shard_id;
 	end = OCF_MIN(portion*(shard_id + 1), entries);
 

--- a/src/cleaning/alru.c
+++ b/src/cleaning/alru.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -516,7 +516,7 @@ static int ocf_alru_recovery_handle(ocf_parallelize_t parallelize,
 	uint32_t step = 0;
 	int i;
 
-	portion = DIV_ROUND_UP((uint64_t)entries, shards_cnt);
+	portion = OCF_DIV_ROUND_UP((uint64_t)entries, shards_cnt);
 	begin = portion*shard_id;
 	end = OCF_MIN((uint64_t)portion*(shard_id + 1), entries);
 

--- a/src/ocf_lru.c
+++ b/src/ocf_lru.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -891,7 +891,7 @@ static int ocf_lru_populate_handle(ocf_parallelize_t parallelize,
 	uint32_t portion, offset;
 	uint32_t i, idx;
 
-	portion = DIV_ROUND_UP((uint64_t)entries, shards_cnt);
+	portion = OCF_DIV_ROUND_UP((uint64_t)entries, shards_cnt);
 	offset = shard_id * portion / shards_cnt;
 	ocf_generator_bisect_init(&generator, portion, offset);
 


### PR DESCRIPTION
It's required, because environments other than Linux kernel may not define
their own DIV_ROUND_UP. Moving it to env would just generate boilerplate,
because its implementation is trivial and portable.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>