### PR TITLE
example: Fix ocf_volume destruction in error handling code

### DIFF
--- a/example/simple/src/main.c
+++ b/example/simple/src/main.c
@@ -169,7 +169,7 @@ err_cache:
 err_priv:
 	free(cache_priv);
 err_vol:
-	ocf_volume_destroy(&volume);
+	ocf_volume_destroy(volume);
 err_sem:
 	sem_destroy(&context.sem);
 	return ret;


### PR DESCRIPTION
Pass the right pointer type to function ocf_volume_destroy().

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>