### PR TITLE
Get rid of req->io_if

### DIFF
--- a/src/engine/cache_engine.h
+++ b/src/engine/cache_engine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -32,10 +32,10 @@ typedef enum {
 	ocf_req_cache_mode_max,
 } ocf_req_cache_mode_t;
 
-struct ocf_io_if {
-	int (*read)(struct ocf_request *req);
+typedef int (*ocf_engine_cb)(struct ocf_request *req);
 
-	int (*write)(struct ocf_request *req);
+struct ocf_io_if {
+	ocf_engine_cb cbs[2]; /* READ and WRITE */
 
 	const char *name;
 };
@@ -43,14 +43,7 @@ struct ocf_io_if {
 void ocf_resolve_effective_cache_mode(ocf_cache_t cache,
 		ocf_core_t core, struct ocf_request *req);
 
-const struct ocf_io_if *ocf_get_io_if(ocf_req_cache_mode_t cache_mode);
-
-static inline const char *ocf_get_io_iface_name(ocf_cache_mode_t cache_mode)
-{
-	const struct ocf_io_if *iface = ocf_get_io_if(cache_mode);
-
-	return iface ? iface->name : "Unknown";
-}
+const char *ocf_get_io_iface_name(ocf_req_cache_mode_t cache_mode);
 
 bool ocf_req_cache_mode_has_lazy_write(ocf_req_cache_mode_t mode);
 

--- a/src/engine/engine_bf.c
+++ b/src/engine/engine_bf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -90,13 +90,8 @@ static int _ocf_backfill_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_backfill = {
-	.read = _ocf_backfill_do,
-	.write = _ocf_backfill_do,
-};
-
 void ocf_engine_backfill(struct ocf_request *req)
 {
 	backfill_queue_inc_block(req->cache);
-	ocf_engine_push_req_front_if(req, &_io_if_backfill, true);
+	ocf_engine_push_req_front_cb(req, _ocf_backfill_do, true);
 }

--- a/src/engine/engine_common.h
+++ b/src/engine/engine_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -304,12 +304,12 @@ void ocf_engine_push_req_front(struct ocf_request *req,
  * @brief Set interface and push from request to the OCF thread worker queue
  *
  * @param req OCF request
- * @param io_if IO interface
+ * @param engine_cb IO engine handler callback
  * @param allow_sync caller allows for request from queue to be ran immediately
 		from push function in caller context
  */
-void ocf_engine_push_req_front_if(struct ocf_request *req,
-		const struct ocf_io_if *io_if,
+void ocf_engine_push_req_front_cb(struct ocf_request *req,
+		ocf_engine_cb engine_cb,
 		bool allow_sync);
 
 void inc_fallback_pt_error_counter(ocf_cache_t cache);

--- a/src/engine/engine_fast.c
+++ b/src/engine/engine_fast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -99,11 +99,6 @@ static int _ocf_read_fast_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_read_fast_resume = {
-	.read = _ocf_read_fast_do,
-	.write = _ocf_read_fast_do,
-};
-
 int ocf_read_fast(struct ocf_request *req)
 {
 	bool hit;
@@ -113,8 +108,8 @@ int ocf_read_fast(struct ocf_request *req)
 	/* Get OCF request - increase reference counter */
 	ocf_req_get(req);
 
-	/* Set resume io_if */
-	req->io_if = &_io_if_read_fast_resume;
+	/* Set resume handler */
+	req->engine_handler = _ocf_read_fast_do;
 
 	/*- Metadata RD access -----------------------------------------------*/
 
@@ -171,11 +166,6 @@ int ocf_read_fast(struct ocf_request *req)
  *      \/  \/ |_|  |_|\__\___| |_|  \__,_|___/\__| |_|   \__,_|\__|_| |_|
  */
 
-static const struct ocf_io_if _io_if_write_fast_resume = {
-	.read = ocf_write_wb_do,
-	.write = ocf_write_wb_do,
-};
-
 int ocf_write_fast(struct ocf_request *req)
 {
 	bool mapped;
@@ -185,8 +175,8 @@ int ocf_write_fast(struct ocf_request *req)
 	/* Get OCF request - increase reference counter */
 	ocf_req_get(req);
 
-	/* Set resume io_if */
-	req->io_if = &_io_if_write_fast_resume;
+	/* Set resume handler */
+	req->engine_handler = ocf_write_wb_do;
 
 	/*- Metadata RD access -----------------------------------------------*/
 

--- a/src/engine/engine_inv.c
+++ b/src/engine/engine_inv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -60,12 +60,7 @@ static int _ocf_invalidate_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_invalidate = {
-	.read = _ocf_invalidate_do,
-	.write = _ocf_invalidate_do,
-};
-
 void ocf_engine_invalidate(struct ocf_request *req)
 {
-	ocf_engine_push_req_front_if(req, &_io_if_invalidate, true);
+	ocf_engine_push_req_front_cb(req, _ocf_invalidate_do, true);
 }

--- a/src/engine/engine_rd.c
+++ b/src/engine/engine_rd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -205,11 +205,6 @@ static int _ocf_read_generic_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_read_generic_resume = {
-	.read = _ocf_read_generic_do,
-	.write = _ocf_read_generic_do,
-};
-
 static const struct ocf_engine_callbacks _rd_engine_callbacks =
 {
 	.resume = ocf_engine_on_resume,
@@ -225,7 +220,7 @@ int ocf_read_generic(struct ocf_request *req)
 	if (env_atomic_read(&cache->pending_read_misses_list_blocked)) {
 		/* There are conditions to bypass IO */
 		req->force_pt = true;
-		ocf_get_io_if(ocf_cache_mode_pt)->read(req);
+		ocf_read_pt(req);
 		return 0;
 	}
 
@@ -233,7 +228,7 @@ int ocf_read_generic(struct ocf_request *req)
 	ocf_req_get(req);
 
 	/* Set resume call backs */
-	req->io_if = &_io_if_read_generic_resume;
+	req->engine_handler = _ocf_read_generic_do;
 	req->engine_cbs = &_rd_engine_callbacks;
 
 	lock = ocf_engine_prepare_clines(req);
@@ -255,7 +250,7 @@ int ocf_read_generic(struct ocf_request *req)
 	} else {
 		ocf_req_clear(req);
 		req->force_pt = true;
-		ocf_get_io_if(ocf_cache_mode_pt)->read(req);
+		ocf_read_pt(req);
 	}
 
 

--- a/src/engine/engine_wa.c
+++ b/src/engine/engine_wa.c
@@ -1,10 +1,12 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"
 #include "../ocf_cache_priv.h"
 #include "engine_wa.h"
+#include "engine_wt.h"
+#include "engine_wi.h"
 #include "engine_common.h"
 #include "cache_engine.h"
 #include "../ocf_request.h"
@@ -34,13 +36,13 @@ int ocf_write_wa(struct ocf_request *req)
 		ocf_req_clear(req);
 
 		/* There is HIT, do WT */
-		ocf_get_io_if(ocf_cache_mode_wt)->write(req);
+		ocf_write_wt(req);
 
 	} else {
 		ocf_req_clear(req);
 
 		/* MISS, do WI */
-		ocf_get_io_if(ocf_cache_mode_wi)->write(req);
+		ocf_write_wi(req);
 	}
 
 	/* Put OCF request - decrease reference counter */

--- a/src/engine/engine_wo.c
+++ b/src/engine/engine_wo.c
@@ -150,11 +150,6 @@ static int ocf_read_wo_cache_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_wo_cache_read = {
-	.read = ocf_read_wo_cache_do,
-	.write = ocf_read_wo_cache_do,
-};
-
 static void _ocf_read_wo_core_complete(struct ocf_request *req, int error)
 {
 	if (error) {
@@ -173,7 +168,7 @@ static void _ocf_read_wo_core_complete(struct ocf_request *req, int error)
 		return;
 	}
 
-	req->io_if = &_io_if_wo_cache_read;
+	req->engine_handler = ocf_read_wo_cache_do;
 	ocf_engine_push_req_front(req, true);
 }
 
@@ -206,11 +201,6 @@ int ocf_read_wo_do(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_wo_resume = {
-	.read = ocf_read_wo_do,
-	.write = ocf_read_wo_do,
-};
-
 int ocf_read_wo(struct ocf_request *req)
 {
 	int lock = OCF_LOCK_ACQUIRED;
@@ -223,7 +213,7 @@ int ocf_read_wo(struct ocf_request *req)
 	ocf_req_get(req);
 
 	/* Set resume call backs */
-	req->io_if = &_io_if_wo_resume;
+	req->engine_handler = ocf_read_wo_do;
 
 	ocf_req_hash(req);
 	ocf_hb_req_prot_lock_rd(req); /*- Metadata RD access -----------------------*/

--- a/src/metadata/metadata_passive_update.c
+++ b/src/metadata/metadata_passive_update.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -68,11 +68,6 @@ static int passive_io_resume(struct ocf_request *req)
 	return 0;
 }
 
-static struct ocf_io_if passive_io_restart_if = {
-	.read = passive_io_resume,
-	.write = passive_io_resume,
-};
-
 static void passive_io_page_lock_acquired(struct ocf_request *req)
 {
 	ocf_engine_push_req_front(req, true);
@@ -120,7 +115,7 @@ int ocf_metadata_passive_update(ocf_cache_t cache, struct ocf_io *io,
 
 	req->io_queue = io->io_queue;;
 	req->info.internal = true;
-	req->io_if = &passive_io_restart_if;
+	req->engine_handler = passive_io_resume;
 	req->rw = OCF_WRITE;
 	req->data = io;
 	req->master_io_req = io_cmpl;

--- a/src/metadata/metadata_raw_dynamic.c
+++ b/src/metadata/metadata_raw_dynamic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -376,11 +376,6 @@ static void raw_dynamic_load_all_complete(
 
 static int raw_dynamic_load_all_update(struct ocf_request *req);
 
-static const struct ocf_io_if _io_if_raw_dynamic_load_all_update = {
-	.read = raw_dynamic_load_all_update,
-	.write = raw_dynamic_load_all_update,
-};
-
 static void raw_dynamic_load_all_read_end(struct ocf_io *io, int error)
 {
 	struct raw_dynamic_load_all_context *context = io->priv1;
@@ -392,7 +387,7 @@ static void raw_dynamic_load_all_read_end(struct ocf_io *io, int error)
 		return;
 	}
 
-	context->req->io_if = &_io_if_raw_dynamic_load_all_update;
+	context->req->engine_handler = raw_dynamic_load_all_update;
 	ocf_engine_push_req_front(context->req, true);
 }
 
@@ -436,11 +431,6 @@ static int raw_dynamic_load_all_read(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_raw_dynamic_load_all_read = {
-	.read = raw_dynamic_load_all_read,
-	.write = raw_dynamic_load_all_read,
-};
-
 static int raw_dynamic_load_all_update(struct ocf_request *req)
 {
 	struct raw_dynamic_load_all_context *context = req->priv;
@@ -463,7 +453,7 @@ static int raw_dynamic_load_all_update(struct ocf_request *req)
 		return 0;
 	}
 
-	context->req->io_if = &_io_if_raw_dynamic_load_all_read;
+	context->req->engine_handler = raw_dynamic_load_all_read;
 	ocf_engine_push_req_front(context->req, true);
 
 	return 0;
@@ -508,7 +498,7 @@ void raw_dynamic_load_all(ocf_cache_t cache, struct ocf_metadata_raw *raw,
 
 	context->req->info.internal = true;
 	context->req->priv = context;
-	context->req->io_if = &_io_if_raw_dynamic_load_all_read;
+	context->req->engine_handler = raw_dynamic_load_all_read;
 
 	ocf_engine_push_req_front(context->req, true);
 	return;

--- a/src/mngt/ocf_mngt_flush.c
+++ b/src/mngt/ocf_mngt_flush.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -417,11 +417,6 @@ static int _ofc_flush_container_step(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_flush_portion = {
-	.read = _ofc_flush_container_step,
-	.write = _ofc_flush_container_step,
-};
-
 static void _ocf_mngt_flush_container(
 		struct ocf_mngt_cache_flush_context *context,
 		struct flush_container *fc, ocf_flush_containter_coplete_t end)
@@ -443,7 +438,7 @@ static void _ocf_mngt_flush_container(
 	}
 
 	req->info.internal = true;
-	req->io_if = &_io_if_flush_portion;
+	req->engine_handler = _ofc_flush_container_step;
 	req->priv = fc;
 
 	fc->req = req;

--- a/src/ocf_queue.c
+++ b/src/ocf_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"
@@ -85,10 +85,7 @@ void ocf_io_handle(struct ocf_io *io, void *opaque)
 
 	OCF_CHECK_NULL(req);
 
-	if (req->rw == OCF_WRITE)
-		req->io_if->write(req);
-	else
-		req->io_if->read(req);
+	req->engine_handler(req);
 }
 
 void ocf_queue_run_single(ocf_queue_t q)

--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -128,8 +128,8 @@ struct ocf_request {
 	ocf_core_t core;
 	/*!< Handle to core instance */
 
-	const struct ocf_io_if *io_if;
-	/*!< IO interface */
+	ocf_engine_cb engine_handler;
+	/*!< IO engine handler */
 
 	void *priv;
 	/*!< Filed for private data, context */

--- a/src/utils/utils_parallelize.c
+++ b/src/utils/utils_parallelize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012-2022 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -45,11 +45,6 @@ static int _ocf_parallelize_hndl(struct ocf_request *req)
 
 	return 0;
 }
-
-static const struct ocf_io_if _io_if_parallelize = {
-	.read = _ocf_parallelize_hndl,
-	.write = _ocf_parallelize_hndl,
-};
 
 int ocf_parallelize_create(ocf_parallelize_t *parallelize,
 		ocf_cache_t cache, unsigned shards_cnt, uint32_t priv_size,
@@ -97,7 +92,8 @@ int ocf_parallelize_create(ocf_parallelize_t *parallelize,
 				goto err_reqs;
 			}
 			tmp_parallelize->reqs[i]->info.internal = true;
-			tmp_parallelize->reqs[i]->io_if = &_io_if_parallelize;
+			tmp_parallelize->reqs[i]->engine_handler =
+					_ocf_parallelize_hndl;
 			tmp_parallelize->reqs[i]->byte_position = i;
 			tmp_parallelize->reqs[i]->priv = tmp_parallelize;
 			i++;

--- a/src/utils/utils_pipeline.c
+++ b/src/utils/utils_pipeline.c
@@ -67,11 +67,6 @@ static int _ocf_pipeline_run_step(struct ocf_request *req)
 	return 0;
 }
 
-static const struct ocf_io_if _io_if_pipeline = {
-	.read = _ocf_pipeline_run_step,
-	.write = _ocf_pipeline_run_step,
-};
-
 int ocf_pipeline_create(ocf_pipeline_t *pipeline, ocf_cache_t cache,
 		struct ocf_pipeline_properties *properties)
 {
@@ -101,7 +96,7 @@ int ocf_pipeline_create(ocf_pipeline_t *pipeline, ocf_cache_t cache,
 	tmp_pipeline->error = 0;
 
 	req->info.internal = true;
-	req->io_if = &_io_if_pipeline;
+	req->engine_handler = _ocf_pipeline_run_step;
 	req->priv = tmp_pipeline;
 
 	*pipeline = tmp_pipeline;


### PR DESCRIPTION
Remove one callback indirection level. I/O never changes it's direction
so there is no point in storing both read and write callbacks for each request.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>