### PR TITLE
Adding extra script for running PyOCF with sanitization

### DIFF
--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -11,9 +11,8 @@ INCDIR=$(ADAPTERDIR)/ocf/include
 WRAPDIR=$(ADAPTERDIR)/c/wrappers
 HELPDIR=$(ADAPTERDIR)/c/helpers
 
-CC=gcc
-CFLAGS=-g -Wall -I$(INCDIR) -I$(SRCDIR)/ocf/env
-LDFLAGS=-pthread -lz
+CFLAGS=-g -Wall -I$(INCDIR) -I$(SRCDIR)/ocf/env $(OPT_CFLAGS)
+LDFLAGS=-pthread #-lz
 
 SRC=$(shell find $(SRCDIR) $(WRAPDIR) $(HELPDIR) -name \*.c)
 OBJS=$(patsubst %.c, %.o, $(SRC))
@@ -48,6 +47,7 @@ distclean: clean
 	@rm -rf $(OCFLIB) $(OBJS)
 	@rm -rf $(SRCDIR)/ocf
 	@rm -rf $(INCDIR)/ocf
+	@find . -name *.gc* -delete
 	@echo "  DISTCLEAN "
 
 .PHONY: all clean sync config_random distclean

--- a/tests/functional/run_with_sanitizers.sh
+++ b/tests/functional/run_with_sanitizers.sh
@@ -1,0 +1,37 @@
+#
+# Copyright(c) 2019-2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#!/usr/bin/env bash
+
+LIB_DIR="/lib/x86_64-linux-gnu/"
+
+ASAN_LIB="$LIB_DIR/libasan.so.6"
+TSAN_LIB="$LIB_DIR/libtsan.so.0"
+UBSAN_LIB="$LIB_DIR/libubsan.so.1"
+
+TEST="tests/basic/test_pyocf.py"
+
+echo "Cleaning and building with Address Sanitizer"
+make distclean
+OPT_CFLAGS="-fsanitize=address" make -j >/dev/null
+echo "Running tests, please wait..."
+LD_PRELOAD=$ASAN_LIB ASAN_OPTIONS=log_output=asan_log.txt pytest -s $TEST #> asan_output.txt 2>&1
+echo "Done, check asan_log.txt"
+
+echo "Cleaning and building with Thread Sanitizer"
+make distclean
+OPT_CFLAGS="-fsanitize=thread" make -j >/dev/null 
+echo "Running tests, please wait..."
+LD_PRELOAD=$TSAN_LIB TSAN_OPTIONS=log_output=tsan_log.txt pytest -s $TEST #> tsan_output.txt 2>&1
+echo "Done, check tsan_log.txt" 
+
+echo "Cleaning and building with Undefined Behaviour Sanitizer"
+make distclean
+OPT_CFLAGS="-fsanitize=undefined -fno-sanitize=alignment" make -j >/dev/null 
+echo "Running tests, please wait..."
+LD_PRELOAD=$UBSAN_LIB UBSAN_OPTIONS=log_output=ubsan_log.txt pytest -s $TEST #> ubsan_output.txt 2>&1
+echo "Done, check ubsan_output.txt" 
+
+


### PR DESCRIPTION
GCC/Clang sanitizer can be used together with PyOCF to catch some errors during testing.

CC was purposely removed from the Makefile. It always points to GCC on Linux by default. This allows to change the compiler and its options during the run of the script

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>