### PR TITLE
alru: add parameter `max_dirty_ratio'

### DIFF
--- a/example/simple/src/main.c
+++ b/example/simple/src/main.c
@@ -94,7 +94,7 @@ int initialize_cache(ocf_ctx_t ctx, ocf_cache_t *cache)
 	ocf_mngt_cache_config_set_default(&cache_cfg);
 	cache_cfg.metadata_volatile = true;
 
-	/* Cache deivce (volume) configuration */
+	/* Cache device (volume) configuration */
 	type = ocf_ctx_get_volume_type(ctx, VOL_TYPE);
 	ret = ocf_uuid_set_str(&uuid, "cache");
 	if (ret)
@@ -260,7 +260,7 @@ void complete_read(struct ocf_io *io, int error)
 {
 	struct volume_data *data = ocf_io_get_data(io);
 
-	printf("WRITE COMPLETE (error: %d)\n", error);
+	printf("READ COMPLETE (error: %d)\n", error);
 	printf("DATA: \"%s\"\n", (char *)data->ptr);
 
 	/* Free data buffer and io */

--- a/inc/cleaning/alru.h
+++ b/inc/cleaning/alru.h
@@ -15,6 +15,7 @@ enum ocf_cleaning_alru_parameters {
 	ocf_alru_stale_buffer_time,
 	ocf_alru_flush_max_buffers,
 	ocf_alru_activity_threshold,
+	ocf_alru_max_dirty_ratio,
 };
 
 /**
@@ -66,6 +67,16 @@ enum ocf_cleaning_alru_parameters {
 /** Idle time before flushing thread can start default value */
 #define OCF_ALRU_DEFAULT_ACTIVITY_THRESHOLD	10000
 
+/**
+ * ALRU max dirty ratio for a cache device
+ */
+
+/** Minimum dirty ratio value */
+#define OCF_ALRU_MIN_MAX_DIRTY_RATIO		0
+/** Maximum dirty ratio value */
+#define OCF_ALRU_MAX_MAX_DIRTY_RATIO		100
+/** Default dirty ratio value */
+#define OCF_ALRU_DEFAULT_MAX_DIRTY_RATIO	OCF_ALRU_MAX_MAX_DIRTY_RATIO
 /**
  * @}
  */

--- a/inc/ocf_mngt.h
+++ b/inc/ocf_mngt.h
@@ -445,9 +445,9 @@ struct ocf_mngt_cache_attach_config {
 };
 
 /**
- * @brief Initialize core config to default values
+ * @brief Initialize attach config to default values
  *
- * @note This function doesn't initiialize uuid and volume_type fields
+ * @note This function doesn't initialize uuid and volume_type fields
  *       which have no default values and are required to be set by user.
  *
  * @param[in] cfg Cache device config stucture

--- a/src/cleaning/alru_structs.h
+++ b/src/cleaning/alru_structs.h
@@ -20,6 +20,7 @@ struct alru_cleaning_policy_config {
 	uint32_t stale_buffer_time;	/* in seconds */
 	uint32_t flush_max_buffers;	/* in lines */
 	uint32_t activity_threshold;	/* in milliseconds */
+	uint32_t max_dirty_ratio;	/* percent */
 };
 
 struct alru_cleaning_policy {


### PR DESCRIPTION
With a high dirty ratio and occupancy, OCF might unable to map cache lines for new requests, thus pass-through the I/O to core devices.  IOPS will drop afterwards.  Existing `alru' policy gives user the chance to control the stale buffer time, activity threshold etc.  They can affect the dirty ratio of the cache device, but in an empirical manner, more or less.  Introducing `max_dirty_ratio' can make it explicit.

At first glance, it might be better to implement a dedicated cleaner policy directly targeting dirty ratio goal, so that the `alru' parameters remains orthogonal.  But one the other hand, we still need to flush dirty cache lines periodically, instead of just keeping a watermark of dirty ratio. It indicates that existing `alru' parameters are still required if we develop a new policy, and it seems reasonable to make it a parameter.

To sum up, this patch does the following:
- added a 'max_dirty_ratio' parameter with default value 100;
- with default value 100, `alru' cleaner is identical to what is was;
- with value N less than 100, the cleaner (when waken up) will active brought dirty ratio to N, regardless of staleness time.

I  have tested this patch with a modified Open-CAS and it works. If any comments, please feel free.