### PR TITLE
Avoid evicting target partition

### DIFF
--- a/src/ocf_space.c
+++ b/src/ocf_space.c
@@ -59,6 +59,9 @@ static inline uint32_t ocf_evict_user_partitions(ocf_cache_t cache,
 		/*
 		 * Check stop and continue conditions
 		 */
+		if (req->part_id == part_id)
+            continue;
+
 		if (max_priority > user_part->config->priority) {
 			/*
 			 * iterate partition have higher priority,


### PR DESCRIPTION
In case when there are ioclasses with the same eviction priority and target ioclass is first on the ioclass list, then the target ioclass is being evicted. To avoid this situation make sure to skip it when choosing ioclass to evict.

Signed-off-by: Damian Raczkowski <damian.raczkowski@intel.com>