### PR TITLE
utils_refcnt_register_zero_cb.c: fix typos

### DIFF
--- a/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_register_zero_cb.c
+++ b/tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_register_zero_cb.c
@@ -87,7 +87,7 @@ static void ocf_refcnt_register_zero_cb_test02(void **state)
 	expect_function_calls(zero_cb, 1);
 	expect_value(zero_cb, ctx, ptr);
 
-	/* regiser callback */
+	/* register callback */
 	ocf_refcnt_register_zero_cb(&rc, zero_cb, ptr);
 
 	val = env_atomic_read(&rc.callback);


### PR DESCRIPTION
tests/unit/tests/utils/utils_refcnt.c/utils_refcnt_register_zero_cb.c: fix typos

Signed-off-by: Rongqi Sun <sunrongqi@huawei.com>