### PR TITLE
[v22.6.1] tests: Use proper random object for string generation

### DIFF
--- a/tests/functional/tests/utils/random.py
+++ b/tests/functional/tests/utils/random.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -79,7 +79,7 @@ class RandomStringGenerator:
                 *extra_chars,
             ]:
                 yield "".join(
-                    random.choice(t)
+                    self.random.choice(t)
                     for _ in range(self.random.randint(len_range.min, len_range.max))
                 )
 


### PR DESCRIPTION
PyOCF needs to control random seed, to allow running tests with pytest-xdist. Use local random object initialized with seed from the config.