### PR TITLE
[v22.6.1] Fix alignment of private data in parallelize & pipeline

### DIFF
--- a/src/utils/utils_parallelize.c
+++ b/src/utils/utils_parallelize.c
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2023 Huawei Technologies
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -8,6 +9,8 @@
 #include "../engine/engine_common.h"
 #include "../ocf_request.h"
 #include "utils_parallelize.h"
+
+#define OCF_PARALLELIZE_ALIGNMENT 64
 
 struct ocf_parallelize {
 	ocf_cache_t cache;
@@ -71,12 +74,15 @@ int ocf_parallelize_create(ocf_parallelize_t *parallelize,
 	prl_size = sizeof(*tmp_parallelize) +
 			shards_cnt * sizeof(*tmp_parallelize->reqs);
 
-	tmp_parallelize = env_vzalloc(prl_size + priv_size);
+	tmp_parallelize = env_vzalloc(prl_size + priv_size + OCF_PARALLELIZE_ALIGNMENT);
 	if (!tmp_parallelize)
 		return -OCF_ERR_NO_MEM;
 
-	if (priv_size > 0)
-		tmp_parallelize->priv = (void *)tmp_parallelize + prl_size;
+	if (priv_size > 0) {
+		uintptr_t priv = (uintptr_t)tmp_parallelize + prl_size;
+		priv = OCF_DIV_ROUND_UP(priv, OCF_PARALLELIZE_ALIGNMENT) * OCF_PARALLELIZE_ALIGNMENT;
+		tmp_parallelize->priv = (void*)priv;
+	}
 
 	tmp_parallelize->cache = cache;
 	tmp_parallelize->handle = handle;

--- a/src/utils/utils_pipeline.c
+++ b/src/utils/utils_pipeline.c
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2019-2022 Intel Corporation
+ * Copyright(c) 2023 Huawei Technologies
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -8,6 +9,8 @@
 #include "../engine/engine_common.h"
 #include "../ocf_request.h"
 #include "utils_pipeline.h"
+
+#define OCF_PIPELINE_ALIGNMENT 64
 
 struct ocf_pipeline {
 	struct ocf_pipeline_properties *properties;
@@ -79,13 +82,14 @@ int ocf_pipeline_create(ocf_pipeline_t *pipeline, ocf_cache_t cache,
 	struct ocf_request *req;
 
 	tmp_pipeline = env_vzalloc(sizeof(*tmp_pipeline) +
-			properties->priv_size);
+			properties->priv_size + OCF_PIPELINE_ALIGNMENT);
 	if (!tmp_pipeline)
 		return -OCF_ERR_NO_MEM;
 
 	if (properties->priv_size > 0) {
-		tmp_pipeline->priv = (void *)tmp_pipeline +
-				sizeof(*tmp_pipeline);
+		uintptr_t priv = (uintptr_t)tmp_pipeline + sizeof(*tmp_pipeline);
+		priv = OCF_DIV_ROUND_UP(priv, OCF_PIPELINE_ALIGNMENT) * OCF_PIPELINE_ALIGNMENT;
+		tmp_pipeline->priv = (void *)priv;
 	}
 
 	req = ocf_req_new(cache->mngt_queue, NULL, 0, 0, 0);


### PR DESCRIPTION
there is an issue when someone call to parallelize/pipeline with some struct that is aligned (say to 64B)
but these APIs add their own data, right before
the user's private data.
so, the user's data is no longer aligned
which might cause segfault in some cases.