### PR TITLE
[v22.6.2] Unlock request in PT using ocf_req_unlock()

### DIFF
--- a/src/engine/engine_pt.c
+++ b/src/engine/engine_pt.c
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2023 Huawei Technologies
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"
@@ -34,7 +35,7 @@ static void _ocf_read_pt_complete(struct ocf_request *req, int error)
 	/* Complete request */
 	req->complete(req, req->error);
 
-	ocf_req_unlock_rd(ocf_cache_line_concurrency(req->cache), req);
+	ocf_req_unlock(ocf_cache_line_concurrency(req->cache), req);
 
 	/* Release OCF request */
 	ocf_req_put(req);


### PR DESCRIPTION
There are situations when we can end up in engine_pt with cache lines locked for write. One example is engine_rd falling back to engine_pt after failure during cache line preparation, where write lock has been already taken. To handle this situation properly, unlock request using more general unlock function.