### PR TITLE
Fix potential deadlock in discard

### DIFF
--- a/src/engine/engine_discard.c
+++ b/src/engine/engine_discard.c
@@ -1,5 +1,6 @@
 /*
  * Copyright(c) 2012-2022 Intel Corporation
+ * Copyright(c) 2024 Huawei Technologies
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ocf/ocf.h"
@@ -152,13 +153,13 @@ int _ocf_discard_step_do(struct ocf_request *req)
 		/* Remove mapped cache lines from metadata */
 		ocf_purge_map_info(req);
 
+		ocf_hb_req_prot_unlock_wr(req);
+
 		if (req->info.flush_metadata) {
 			/* Request was dirty and need to flush metadata */
 			ocf_metadata_flush_do_asynch(cache, req,
 					_ocf_discard_step_complete);
 		}
-
-		ocf_hb_req_prot_unlock_wr(req);
 	}
 
 	ocf_hb_req_prot_lock_rd(req);


### PR DESCRIPTION
HB lock takes inclusive metadata lock, which is taken also by metadata flush, thus trying to call metadata flush under HB lock attempts to take this lock recursively. In that case, if in the meantime some other thread would try to take exclusive metadata lock, the inner inclusive lock would block (because the lock keeps the order), with outer inclusive lock still held, leading to a deadlock.