### PR TITLE
env: posix: fix memset args in env_secure_free()

### DIFF
--- a/env/posix/ocf_env.h
+++ b/env/posix/ocf_env.h
@@ -187,7 +187,7 @@ static inline void env_secure_free(const void *ptr, size_t size)
 {
 	if (ptr) {
 #if SECURE_MEMORY_HANDLING
-		memset(ptr, size, 0);
+		memset(ptr, 0, size);
 		/* TODO: flush CPU caches ? */
 		ENV_BUG_ON(munlock(ptr));
 #endif


### PR DESCRIPTION
The argument order was wrong. See also:
https://bugzilla.suse.com/show_bug.cgi?id=1226132

Fixes issue #794