### PR TITLE
Revert "cleaner: Remove complete_queue"

### DIFF
--- a/src/ocf_request.h
+++ b/src/ocf_request.h
@@ -195,6 +195,9 @@ struct ocf_request {
 	uint8_t part_evict : 1;
 	/* !< Some cachelines from request's partition must be evicted */
 
+	uint8_t complete_queue : 1;
+	/* !< Request needs to be completed from the queue context */
+
 	uint8_t lock_idx : OCF_METADATA_GLOBAL_LOCK_IDX_BITS;
 	/* !< Selected global metadata read lock */
 


### PR DESCRIPTION
This functionality is used by cleaning policies via cmpl_queue to reschedule the completion, so that we avoid unlocking mutex in the cleaner completion from interrupt context of IO completion.

This reverts commit 1e5eda68a7e1abb7e9c6bdfa6c5d2a4f940681dc.