### PR TITLE
Avoid UBSAN false positive

### DIFF
--- a/src/ocf_request.c
+++ b/src/ocf_request.c
@@ -227,7 +227,7 @@ struct ocf_request *ocf_req_new(ocf_queue_t queue, ocf_core_t core,
 
 	if (map_allocated) {
 		req->map = req->__map;
-		req->alock_status = (uint8_t*)&req->__map[core_line_count];
+		req->alock_status = (uint8_t*)&req->map[core_line_count];
 		req->alloc_core_line_count = core_line_count;
 	} else {
 		req->alloc_core_line_count = 1;


### PR DESCRIPTION
UBSAN: array-index-out-of-bounds in src/ocf_request.c:230:44
index 1 is out of range for type 'ocf_map_info [*]'