### PR TITLE
Check if cache is attached before setting promotion and seqcutoff params

### DIFF
--- a/src/mngt/ocf_mngt_cache.c
+++ b/src/mngt/ocf_mngt_cache.c
@@ -3733,6 +3733,9 @@ int ocf_mngt_cache_promotion_set_param(ocf_cache_t cache, ocf_promotion_t type,
 	if (ocf_cache_is_standby(cache))
 		return -OCF_ERR_CACHE_STANDBY;
 
+	if (!ocf_cache_is_device_attached(cache))
+		return -OCF_ERR_CACHE_DETACHED;
+
 	ocf_metadata_start_exclusive_access(&cache->metadata.lock);
 
 	result = ocf_promotion_set_param(cache, type, param_id, param_value);

--- a/src/mngt/ocf_mngt_core.c
+++ b/src/mngt/ocf_mngt_core.c
@@ -1258,6 +1258,9 @@ int ocf_mngt_core_set_seq_cutoff_promote_on_threshold(ocf_core_t core,
 	if (ocf_cache_is_standby(cache))
 		return -OCF_ERR_CACHE_STANDBY;
 
+	if (!ocf_cache_is_device_attached(cache))
+		return -OCF_ERR_CACHE_DETACHED;
+
 	return _cache_mngt_set_core_seq_cutoff_promote_on_threshold(core, &promote);
 }
 
@@ -1268,6 +1271,9 @@ int ocf_mngt_core_set_seq_cutoff_promote_on_threshold_all(ocf_cache_t cache,
 
 	if (ocf_cache_is_standby(cache))
 		return -OCF_ERR_CACHE_STANDBY;
+
+	if (!ocf_cache_is_device_attached(cache))
+		return -OCF_ERR_CACHE_DETACHED;
 
 	return ocf_core_visit(cache,
 			_cache_mngt_set_core_seq_cutoff_promote_on_threshold,


### PR DESCRIPTION
Fixes null pointer dereference if setting those params is attempted on detached cache.