### PR TITLE
Fix test script shebang

### DIFF
--- a/tests/functional/run_with_sanitizers.sh
+++ b/tests/functional/run_with_sanitizers.sh
@@ -1,10 +1,10 @@
+#!/usr/bin/env bash
+
 #
 # Copyright(c) 2019-2022 Intel Corporation
 # Copyright(c) 2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
-
-#!/usr/bin/env bash
 
 LIB_DIR="/lib/x86_64-linux-gnu/"
 


### PR DESCRIPTION
Shebang should be the first line of the script to work properly.
Also it solves the "executable-not-elf-or-script" warning during DEB package building.