### PR TITLE
Sort flush data only if there is anything to flush

### DIFF
--- a/src/utils/utils_cleaner.c
+++ b/src/utils/utils_cleaner.c
@@ -837,8 +837,9 @@ void ocf_cleaner_sort_flush_containers(struct flush_container *fctbl,
 	int i;
 
 	for (i = 0; i < num; i++) {
-		ocf_cleaner_sort_flush_data(fctbl[i].flush_data,
-				fctbl[i].count);
+		if (fctbl[i].count > 1)
+			ocf_cleaner_sort_flush_data(fctbl[i].flush_data,
+					fctbl[i].count);
 	}
 }
 


### PR DESCRIPTION
If there is nothing to sort, the env_sort() is called with NULL pointer instead of the first element of array to sort.
This could be fixed in specific implementation of env_sort() to return immediately if number of elements is 0 but all other routines check the element count before calling ocf_cleaner_sort_flush_data() except of ocf_cleaner_sort_flush_containers(), so putting this check there seems more appropriate and makes flush data sorting less prone to errors.