### PR TITLE
[v26.03.1] metadata: Prevent read hoisting in hash bucket lock

### DIFF
--- a/src/concurrency/ocf_metadata_concurrency.c
+++ b/src/concurrency/ocf_metadata_concurrency.c
@@ -76,7 +76,7 @@ static inline int hash_lock_lock(struct ocf_cache *cache,
 	uint32_t step = 0;
 
 	while (1) {
-		newline.raw = curline.raw = entry->raw;
+		newline.raw = curline.raw = env_atomic_read(entry_raw);
 
 		if (curline.wr)
 			goto next;
@@ -111,7 +111,7 @@ static inline void hash_lock_unlock(struct ocf_cache *cache, int index, int rw)
 	uint32_t step = 0;
 
 	while (1) {
-		newline.raw = curline.raw = entry->raw;
+		newline.raw = curline.raw = env_atomic_read(entry_raw);
 
 		if (curline.wr) {
 			newline.wr = 0;


### PR DESCRIPTION
Replace plain read with atomic read to prevent compiler from read hoisting the entry value. So far the loop indirectly relied on OCF_COND_RESCHED_DEFAULT() acting as a opaque barrier, which does not need to be the case, especially in environments where OCF_COND_RESCHED_DEFAULT() is implemented as no-op.