### PR TITLE
Align cleaning, promotion and prefetch policy config structs

### DIFF
--- a/src/cleaning/cleaning.h
+++ b/src/cleaning/cleaning.h
@@ -22,7 +22,7 @@ struct ocf_request;
 
 struct cleaning_policy_config {
 	uint8_t data[CLEANING_POLICY_CONFIG_BYTES];
-};
+} __attribute__((aligned(4)));
 
 struct cleaning_policy {
 	union {

--- a/src/prefetch/ocf_prefetch_priv.h
+++ b/src/prefetch/ocf_prefetch_priv.h
@@ -19,7 +19,7 @@
 
 struct prefetch_policy_config {
 	uint8_t data[PREFETCH_POLICY_CONFIG_BYTES];
-};
+} __attribute__((aligned(4)));
 
 #define OCF_PF_ID_VALID(pf_id) ((pf_id) != ocf_pf_none && (pf_id) < ocf_pf_num)
 #define OCF_PF_ID_ENABLED(pf_id, enabled_mask) ((1 << ((pf_id))) & enabled_mask)

--- a/src/promotion/promotion.h
+++ b/src/promotion/promotion.h
@@ -15,7 +15,7 @@
 
 struct promotion_policy_config {
 	uint8_t data[PROMOTION_POLICY_CONFIG_BYTES];
-};
+} __attribute__((aligned(4)));
 
 typedef struct ocf_promotion_policy *ocf_promotion_policy_t;
 


### PR DESCRIPTION
This properly alignes data and prevents UBSan from reporting misalignment errors.

Fixes https://github.com/Open-CAS/ocf/issues/961