### PR TITLE
Eliminate C23 extensions

### DIFF
--- a/inc/ocf_prefetch.h
+++ b/inc/ocf_prefetch.h
@@ -21,7 +21,9 @@ typedef enum {
 typedef uint8_t ocf_pf_mask_t;
 
 /* The bitmask must fit all the values of ocf_pf_id_t */
-_Static_assert(OCF_BITWIDTH(ocf_pf_mask_t) >= ocf_pf_num);
+_Static_assert(OCF_BITWIDTH(ocf_pf_mask_t) >= ocf_pf_num,
+	       "Not enough bits in ocf_pf_mask_t to store "
+	       "all the values of ocf_pf_id_t enum");
 
 #define OCF_PF_MASK_DEFAULT 0
 

--- a/src/metadata/metadata_collision.h
+++ b/src/metadata/metadata_collision.h
@@ -29,7 +29,8 @@ struct ocf_metadata_list_info {
 };
 
 /* Keep the struct ocf_metadata_list_info size of 8 bytes */
-_Static_assert(sizeof(struct ocf_metadata_list_info) == sizeof(uint64_t));
+_Static_assert(sizeof(struct ocf_metadata_list_info) == sizeof(uint64_t),
+	       "Size of struct ocf_metadata_list_info is not equal to 8 bytes");
 
 struct ocf_hash_entry {
 	union {


### PR DESCRIPTION
SPDK doesn't allow using C23 extensions and throws an error in the upstream CI during compilation:
"error: '_Static_assert' with no message is a C23 extension [-Werror,-Wc23-extensions]"

Add a message as a second argument for _Static_assert() to avoid using C23 extensions.